### PR TITLE
fix: Correct send_mail recipients parameter in action.py

### DIFF
--- a/djangocms_form_builder/actions.py
+++ b/djangocms_form_builder/actions.py
@@ -216,8 +216,8 @@ class SendMailAction(FormAction):
             send_mail(
                 subject,
                 message,
-                recipients,
                 self.from_mail,
+                recipients.split(),
                 fail_silently=True,
                 html_message=html_message,
             )


### PR DESCRIPTION
When an editor opts for sending mail as action for a form there was a bug in `action.py` with filling parameters for the `send_mail` function. As a result mail was not sent.

This patch corrects this.

## Summary by Sourcery

Bug Fixes:
- Correct the order of arguments when calling the `send_mail` function, ensuring that emails are sent to the intended recipients.