### PR TITLE
docs: Update Codecov link in  README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -172,7 +172,7 @@ Actions are not available for Django forms. Any actions to be performed upon sub
 .. |pypi| image:: https://badge.fury.io/py/djangocms-form-builder.svg
    :target: http://badge.fury.io/py/djangocms-form-builder
 
-.. |coverage| image:: https://codecov.io/gh/django-cms/djangocms-form-builder/branch/master/graph/badge.svg
+.. |coverage| image:: https://codecov.io/gh/django-cms/djangocms-form-builder/branch/main/graph/badge.svg
    :target: https://codecov.io/gh/django-cms/djangocms-form-builder
 
 .. |python| image:: https://img.shields.io/badge/python-3.7+-blue.svg


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update the Codecov badge link in README.rst.