### PR TITLE
feat: Allow caching of form plugin

### DIFF
--- a/djangocms_form_builder/cms_plugins/ajax_plugins.py
+++ b/djangocms_form_builder/cms_plugins/ajax_plugins.py
@@ -3,7 +3,8 @@ from urllib.parse import urlencode
 
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
-from django.http import Http404, JsonResponse
+from django.conf import settings as django_settings
+from django.http import Http404, HttpResponseNotAllowed, JsonResponse
 from django.middleware.csrf import get_token
 from django.template.context_processors import csrf
 from django.template.loader import render_to_string
@@ -28,6 +29,12 @@ class CMSAjaxBase(CMSPluginBase):
         return JsonResponse({})
 
     def ajax_get(self, request, instance, parameter):
+        # When CSRF_COOKIE_HTTPONLY is set, the site has explicitly chosen to keep
+        # the token away from JavaScript. Don't undermine that by returning it
+        # here - the form template renders {% csrf_token %} inline instead and
+        # the plugin is not cached (see FormPlugin.cache).
+        if django_settings.CSRF_COOKIE_HTTPONLY:
+            return HttpResponseNotAllowed(["POST"])
         return JsonResponse({"csrf_token": get_token(request)})
 
 
@@ -231,6 +238,7 @@ class CMSAjaxForm(AjaxFormMixin, CMSAjaxBase):
                 "form": form,
                 "uid": f"{instance.id}{getattr(form, 'slug', '')}-{context['form_counter']}",
                 "has_submit_button": has_submit_button(instance.child_plugin_instances),
+                "csrf_cookie_httponly": django_settings.CSRF_COOKIE_HTTPONLY,
             }
         )
         return context
@@ -245,6 +253,11 @@ class FormPlugin(ActionMixin, CMSAjaxForm):
     render_template = f"djangocms_form_builder/{settings.framework}/form.html"
     change_form_template = "djangocms_frontend/admin/base.html"
     allow_children = True
+    # Form HTML is cache-safe only when the CSRF token can be fetched at submit
+    # time via the JSON GET endpoint. When CSRF_COOKIE_HTTPONLY is on, the token
+    # must be embedded inline by {% csrf_token %}, so the rendered HTML carries
+    # per-request data and cannot be cached.
+    cache = not django_settings.CSRF_COOKIE_HTTPONLY
 
     fieldsets = [
         (

--- a/djangocms_form_builder/cms_plugins/ajax_plugins.py
+++ b/djangocms_form_builder/cms_plugins/ajax_plugins.py
@@ -3,7 +3,8 @@ from urllib.parse import urlencode
 
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
-from django.http import Http404, HttpResponseNotAllowed, JsonResponse
+from django.http import Http404, JsonResponse
+from django.middleware.csrf import get_token
 from django.template.context_processors import csrf
 from django.template.loader import render_to_string
 from django.urls import NoReverseMatch, reverse
@@ -27,7 +28,7 @@ class CMSAjaxBase(CMSPluginBase):
         return JsonResponse({})
 
     def ajax_get(self, request, instance, parameter):
-        return HttpResponseNotAllowed(["POST"])
+        return JsonResponse({"csrf_token": get_token(request)})
 
 
 class AjaxFormMixin(FormMixin):
@@ -244,7 +245,6 @@ class FormPlugin(ActionMixin, CMSAjaxForm):
     render_template = f"djangocms_form_builder/{settings.framework}/form.html"
     change_form_template = "djangocms_frontend/admin/base.html"
     allow_children = True
-    cache = False
 
     fieldsets = [
         (

--- a/djangocms_form_builder/static/djangocms_form_builder/js/ajax_form.js
+++ b/djangocms_form_builder/static/djangocms_form_builder/js/ajax_form.js
@@ -111,24 +111,11 @@ function djangocms_form_builder_form(form) {
           .catch(() => null);
     }
 
-    const post_ajax = (node) => {
-        const tokenPromise = form.csrfToken
-            ? Promise.resolve(form.csrfToken)
-            : fetchCsrfToken(node).then((token) => {
-                form.csrfToken = token;
-                return token;
-            });
-
-        tokenPromise.then((csrfToken) => {
-            const headers = {};
-            if (csrfToken) {
-                headers['X-CSRFToken'] = csrfToken;
-            }
-            return fetch(node.getAttribute('action'),{
-                method: 'POST',
-                headers: headers,
-                body: new URLSearchParams(new FormData(node)),
-            });
+    const submitForm = (node, headers) => {
+        return fetch(node.getAttribute('action'),{
+            method: 'POST',
+            headers: headers,
+            body: new URLSearchParams(new FormData(node)),
         }).then((response) => {
             return response.json();
         }).then((data) => {
@@ -136,6 +123,25 @@ function djangocms_form_builder_form(form) {
         }).catch((json) => {
             console.error(json);
             alert(getErrorMessage());
+        });
+    }
+
+    const post_ajax = (node) => {
+        // If the form already carries an inline csrfmiddlewaretoken (rendered when
+        // CSRF_COOKIE_HTTPONLY is on), submit as-is - the token rides in the body.
+        if (node.querySelector('input[name="csrfmiddlewaretoken"]')) {
+            return submitForm(node, {});
+        }
+        // Otherwise fetch the token from the JSON GET endpoint and send it as a
+        // header. Cache it on the form node so subsequent submits skip the GET.
+        const tokenPromise = form.csrfToken
+            ? Promise.resolve(form.csrfToken)
+            : fetchCsrfToken(node).then((token) => {
+                form.csrfToken = token;
+                return token;
+            });
+        tokenPromise.then((csrfToken) => {
+            return submitForm(node, csrfToken ? { 'X-CSRFToken': csrfToken } : {});
         });
     }
 

--- a/djangocms_form_builder/static/djangocms_form_builder/js/ajax_form.js
+++ b/djangocms_form_builder/static/djangocms_form_builder/js/ajax_form.js
@@ -102,12 +102,34 @@ function djangocms_form_builder_form(form) {
         }
     }
 
+    const fetchCsrfToken = (node) => {
+        return fetch(node.getAttribute('action'), {
+            method: 'GET',
+            headers: { 'Accept': 'application/json' },
+        }).then((response) => response.json())
+          .then((data) => (data && data.csrf_token) || null)
+          .catch(() => null);
+    }
+
     const post_ajax = (node) => {
-        fetch(node.getAttribute('action'),{
-            method: 'POST',
-            body: new URLSearchParams(new FormData(node)),
+        const tokenPromise = form.csrfToken
+            ? Promise.resolve(form.csrfToken)
+            : fetchCsrfToken(node).then((token) => {
+                form.csrfToken = token;
+                return token;
+            });
+
+        tokenPromise.then((csrfToken) => {
+            const headers = {};
+            if (csrfToken) {
+                headers['X-CSRFToken'] = csrfToken;
             }
-        ).then((response) => {
+            return fetch(node.getAttribute('action'),{
+                method: 'POST',
+                headers: headers,
+                body: new URLSearchParams(new FormData(node)),
+            });
+        }).then((response) => {
             return response.json();
         }).then((data) => {
             feedback(node, data);

--- a/djangocms_form_builder/templates/djangocms_form_builder/bootstrap5/form.html
+++ b/djangocms_form_builder/templates/djangocms_form_builder/bootstrap5/form.html
@@ -5,6 +5,7 @@
               class="djangocms-form-builder-ajax-form"
               novalidate action="{% url 'form_builder:ajaxview' instance.id %}"
               method="post">
+            {% if csrf_cookie_httponly %}{% csrf_token %}{% endif %}
             {% include 'djangocms_form_builder/ajax_form.html' with form=form instance=instance tracking=instance.tracking_code RECAPTCHA_PUBLIC_KEY=RECAPTCHA_PUBLIC_KEY %}
             {% if not has_submit_button %}
                 <input type="submit" value="{{ instance.form_submit_message|default:_("Submit") }}"

--- a/djangocms_form_builder/templates/djangocms_form_builder/bootstrap5/form.html
+++ b/djangocms_form_builder/templates/djangocms_form_builder/bootstrap5/form.html
@@ -5,7 +5,6 @@
               class="djangocms-form-builder-ajax-form"
               novalidate action="{% url 'form_builder:ajaxview' instance.id %}"
               method="post">
-            {% csrf_token %}
             {% include 'djangocms_form_builder/ajax_form.html' with form=form instance=instance tracking=instance.tracking_code RECAPTCHA_PUBLIC_KEY=RECAPTCHA_PUBLIC_KEY %}
             {% if not has_submit_button %}
                 <input type="submit" value="{{ instance.form_submit_message|default:_("Submit") }}"

--- a/djangocms_form_builder/views.py
+++ b/djangocms_form_builder/views.py
@@ -41,6 +41,10 @@ class AjaxView(View):
     this view allows django CMS plugins to receive ajax requests if they implement the `ajax_get` and
     `ajax_post` methods. The form plugin implements the `ajax_post` method to handle form submissions.
 
+    GET requests return a freshly-minted CSRF token in the JSON body, which
+    ``ajax_form.js`` uses for the ``X-CSRFToken`` header on the subsequent POST.
+    This works regardless of ``CSRF_COOKIE_HTTPONLY`` or ``CSRF_USE_SESSIONS``.
+
     Methods
     -------
 

--- a/tests/test_ajax_plugin.py
+++ b/tests/test_ajax_plugin.py
@@ -5,7 +5,7 @@ from urllib.parse import urlencode
 from cms import __version__ as cms_version
 from cms.api import add_plugin
 from cms.test_utils.testcases import CMSTestCase
-from django.http import HttpResponseNotAllowed, JsonResponse
+from django.http import JsonResponse
 from django.test import RequestFactory
 from django.urls import reverse
 
@@ -497,17 +497,20 @@ class AjaxGetRequestTestCase(TestFixture, CMSTestCase):
         char_field.initialize_from_form()
         return form_plugin
 
-    def test_ajax_get_returns_form_content(self):
-        """Test that AJAX GET request is rejected with HTTP 405"""
+    def test_ajax_get_returns_csrf_token(self):
+        """AJAX GET returns a fresh CSRF token in the JSON body so ajax_form.js
+        can use it as the X-CSRFToken header on the subsequent POST."""
         form_plugin = self._create_simple_form_plugin("simple-ajax-get")
         self.publish(self.page, self.language)
 
         url = reverse("form_builder:ajaxview", kwargs={"instance_id": form_plugin.pk})
-        response = self.client.get(url, headers={"x-requested-with": "XMLHttpRequest"})
+        response = self.client.get(url, headers={"accept": "application/json"})
 
-        self.assertEqual(response.status_code, 405)
-        self.assertIsInstance(response, HttpResponseNotAllowed)
-        self.assertEqual(response["Allow"], "POST")
+        self.assertEqual(response.status_code, 200)
+        self.assertIsInstance(response, JsonResponse)
+        payload = response.json()
+        self.assertIn("csrf_token", payload)
+        self.assertTrue(payload["csrf_token"])
 
     def test_ajax_post_simple_form_submission(self):
         """Test that AJAX POST submits a simple form plugin"""

--- a/tests/test_ajax_plugin.py
+++ b/tests/test_ajax_plugin.py
@@ -5,8 +5,8 @@ from urllib.parse import urlencode
 from cms import __version__ as cms_version
 from cms.api import add_plugin
 from cms.test_utils.testcases import CMSTestCase
-from django.http import JsonResponse
-from django.test import RequestFactory
+from django.http import HttpResponseNotAllowed, JsonResponse
+from django.test import RequestFactory, override_settings
 from django.urls import reverse
 
 from djangocms_form_builder import cms_plugins
@@ -497,6 +497,7 @@ class AjaxGetRequestTestCase(TestFixture, CMSTestCase):
         char_field.initialize_from_form()
         return form_plugin
 
+    @override_settings(CSRF_COOKIE_HTTPONLY=False)
     def test_ajax_get_returns_csrf_token(self):
         """AJAX GET returns a fresh CSRF token in the JSON body so ajax_form.js
         can use it as the X-CSRFToken header on the subsequent POST."""
@@ -511,6 +512,19 @@ class AjaxGetRequestTestCase(TestFixture, CMSTestCase):
         payload = response.json()
         self.assertIn("csrf_token", payload)
         self.assertTrue(payload["csrf_token"])
+
+    @override_settings(CSRF_COOKIE_HTTPONLY=True)
+    def test_ajax_get_does_not_leak_token_when_cookie_httponly(self):
+        """When CSRF_COOKIE_HTTPONLY is on, the GET endpoint must not expose the
+        token - the form template renders it inline instead."""
+        form_plugin = self._create_simple_form_plugin("simple-ajax-get-httponly")
+        self.publish(self.page, self.language)
+
+        url = reverse("form_builder:ajaxview", kwargs={"instance_id": form_plugin.pk})
+        response = self.client.get(url, headers={"accept": "application/json"})
+
+        self.assertEqual(response.status_code, 405)
+        self.assertIsInstance(response, HttpResponseNotAllowed)
 
     def test_ajax_post_simple_form_submission(self):
         """Test that AJAX POST submits a simple form plugin"""

--- a/tests/test_form_rendering.py
+++ b/tests/test_form_rendering.py
@@ -452,8 +452,12 @@ class FormSubmissionRenderingTestCase(TestFixture, CMSTestCase):
         self.assertEqual(json_data["result"], "invalid form")
         self.assertIn("field_errors", json_data)
 
-    def test_form_csrf_token_rendered(self):
-        """Test that CSRF token is present in rendered form"""
+    def test_form_csrf_token_not_rendered(self):
+        """CSRF token must not be rendered inside the form so the HTML stays cacheable.
+
+        The token is read from the csrftoken cookie by ajax_form.js and sent as the
+        X-CSRFToken header instead.
+        """
         form_plugin = add_plugin(
             placeholder=self.placeholder,
             plugin_type=cms_plugins.FormPlugin.__name__,
@@ -483,6 +487,5 @@ class FormSubmissionRenderingTestCase(TestFixture, CMSTestCase):
         self.assertEqual(response.status_code, 200)
         content = response.content.decode()
 
-        # CSRF token must be present
-        self.assertIn('name="csrfmiddlewaretoken"', content)
-        self.assertIn('type="hidden"', content)
+        # CSRF token must NOT be present in the rendered form (cacheable HTML)
+        self.assertNotIn('name="csrfmiddlewaretoken"', content)

--- a/tests/test_form_rendering.py
+++ b/tests/test_form_rendering.py
@@ -6,7 +6,7 @@ from cms.api import add_plugin
 from cms.test_utils.testcases import CMSTestCase
 from django import forms
 from django.template import Context, Template
-from django.test import RequestFactory
+from django.test import RequestFactory, override_settings
 
 from djangocms_form_builder import cms_plugins, recaptcha
 
@@ -452,12 +452,7 @@ class FormSubmissionRenderingTestCase(TestFixture, CMSTestCase):
         self.assertEqual(json_data["result"], "invalid form")
         self.assertIn("field_errors", json_data)
 
-    def test_form_csrf_token_not_rendered(self):
-        """CSRF token must not be rendered inside the form so the HTML stays cacheable.
-
-        The token is read from the csrftoken cookie by ajax_form.js and sent as the
-        X-CSRFToken header instead.
-        """
+    def _render_form_page(self):
         form_plugin = add_plugin(
             placeholder=self.placeholder,
             plugin_type=cms_plugins.FormPlugin.__name__,
@@ -465,8 +460,6 @@ class FormSubmissionRenderingTestCase(TestFixture, CMSTestCase):
             form_selection="",
             form_name="csrf-test",
         )
-
-        # Add at least one field so form renders
         char_field = add_plugin(
             placeholder=self.placeholder,
             plugin_type=cms_plugins.CharFieldPlugin.__name__,
@@ -478,14 +471,28 @@ class FormSubmissionRenderingTestCase(TestFixture, CMSTestCase):
             },
         )
         char_field.initialize_from_form()
-
         self.publish(self.page, self.language)
 
         with self.login_user_context(self.superuser):
             response = self.client.get(self.request_url)
+        return response
+
+    @override_settings(CSRF_COOKIE_HTTPONLY=False)
+    def test_form_csrf_token_not_rendered_when_cookie_readable(self):
+        """With the default CSRF_COOKIE_HTTPONLY=False, the form HTML is cacheable
+        and the token is fetched at submit time via the JSON GET endpoint."""
+        response = self._render_form_page()
 
         self.assertEqual(response.status_code, 200)
         content = response.content.decode()
-
-        # CSRF token must NOT be present in the rendered form (cacheable HTML)
         self.assertNotIn('name="csrfmiddlewaretoken"', content)
+
+    @override_settings(CSRF_COOKIE_HTTPONLY=True)
+    def test_form_csrf_token_rendered_when_cookie_httponly(self):
+        """With CSRF_COOKIE_HTTPONLY=True, JS cannot read the cookie so the token
+        must be embedded inline (and the plugin is non-cacheable)."""
+        response = self._render_form_page()
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn('name="csrfmiddlewaretoken"', content)

--- a/tests/test_formeditor.py
+++ b/tests/test_formeditor.py
@@ -44,7 +44,9 @@ class FormEditorTestCase(TestFixture, CMSTestCase):
             response = self.client.get(self.request_url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'action="/@form-builder/1"')
-        self.assertContains(response, '<input type="hidden" name="csrfmiddlewaretoken"')
+        self.assertNotContains(
+            response, '<input type="hidden" name="csrfmiddlewaretoken"'
+        )
         for item, cls in cms_plugins.__dict__.items():
             if (
                 inspect.isclass(cls)


### PR DESCRIPTION
## Summary by Sourcery

Allow AJAX form plugins to be cacheable by moving CSRF handling out of the rendered HTML into an AJAX-based token retrieval flow.

New Features:
- Return a fresh CSRF token from the AJAX GET endpoint so the frontend can include it as the X-CSRFToken header on subsequent POSTs.

Enhancements:
- Update ajax_form.js to fetch and cache CSRF tokens via JSON GET before posting forms, adding the token as an X-CSRFToken header when available.
- Enable caching of the form plugin by removing the CSRF token field from the rendered form HTML and relying on the AJAX-based CSRF flow instead.

Tests:
- Adjust and extend tests to cover the new CSRF token JSON response, absence of CSRF hidden fields in rendered forms and form editor, and the new AJAX interaction.


Context:
- fixes #51 
- undoes #50 
