### PR TITLE
feat: Security hardening for public forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ local.sqlite
 /private/sass/bootstrap/
 /htmlcov/
 .history/
+htmlcov/
+docs/_build/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,32 @@
 Changelog
 =========
 
+Unreleased
+==========
+
+* feat: Add ``prune_form_entries`` management command to enforce a retention
+  policy for stored form entries
+* feat: The send email action logs failed deliveries to the
+  ``djangocms_form_builder.actions`` logger instead of silently dropping them
+* fix: Make ``djangocms-text`` a soft dependency - the success message action
+  falls back to a plain textarea if it is not installed
+* fix: ``SaveToDBAction`` no longer stores the ``User-Agent`` and ``Referer``
+  request headers (which also caused a server error when the headers were
+  absent); the ``html_headers`` field is no longer populated
+* fix: Captcha configuration parameters (``data-*`` attributes and api
+  parameters) were never passed to the captcha widget
+* fix: Make the database schema independent of installed captcha packages to
+  avoid spurious migrations in user projects
+* fix: ``register_form_view`` raises ``ImproperlyConfigured`` instead of using
+  ``assert`` (which is stripped in optimized mode) for duplicate slugs
+* fix: Correct verbose names of ``DateTimeField`` and ``TimeField`` models
+* fix: Escape help texts, validation error messages and attribute names when
+  rendering widgets
+* fix: Reserved form field name list contained ``html_header`` instead of
+  ``html_headers``
+* chore: Remove dead code inherited from djangocms-frontend (device choice
+  fields, icon widgets, template helpers, form mixin stubs, and more)
+
 0.5.1 (2026-06-01)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -169,6 +169,31 @@ Upon form submission a ``save()`` method of the form (if it has one). After exec
 Actions are not available for Django forms. Any actions to be performed upon submission should reside in its ``save()`` method.
 
 
+Recommendations for public forms
+================================
+
+-  **Enable a captcha on public forms.** Forms without captcha protection have
+   no anti-spam measures and will attract automated submissions. We recommend
+   `Altcha <https://altcha.org/>`_ (see the next section): it is open source,
+   GDPR-compliant and - in built-in mode - works fully self-hosted, without
+   API keys or calls to external services.
+
+-  **Limit how long submissions are kept.** Form submissions stored by the
+   "Save form submission" action may contain personal data. Use the
+   ``prune_form_entries`` management command to enforce a retention policy,
+   e.g., from a cron job::
+
+       python manage.py prune_form_entries --days 90
+
+   ``--form-name <name>`` restricts pruning to a single form, and
+   ``--dry-run`` only reports how many entries would be deleted.
+
+-  **Monitor email delivery.** The "Send email" action does not abort a form
+   submission if sending the email fails. Failures are logged to the
+   ``djangocms_form_builder.actions`` logger - make sure your ``LOGGING``
+   setup surfaces its error messages so failed deliveries are noticed.
+
+
 Configuring Altcha CAPTCHA
 ==========================
 

--- a/djangocms_form_builder/actions.py
+++ b/djangocms_form_builder/actions.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 
 from django import forms
 from django.apps import apps
@@ -8,13 +9,24 @@ from django.template import TemplateDoesNotExist
 from django.template.loader import render_to_string
 from django.utils.html import strip_tags
 from django.utils.translation import gettext_lazy as _
-from djangocms_text.fields import HTMLFormField
 from entangled.forms import EntangledModelFormMixin
+
+try:
+    from djangocms_text.fields import HTMLFormField
+except ModuleNotFoundError:
+
+    class HTMLFormField(forms.CharField):
+        """Plain-text fallback if djangocms-text is not installed."""
+
+        widget = forms.Textarea
+
 
 from . import models
 from .entry_model import FormEntry
 from .helpers import get_option, insert_fields
 from .settings import MAIL_TEMPLATE_SETS
+
+logger = logging.getLogger(__name__)
 
 _action_registry = {}
 
@@ -123,15 +135,7 @@ class SaveToDBAction(FormAction):
                 "form_name": get_option(form, "form_name"),
                 "form_user": None if request.user.is_anonymous else request.user,
             }
-        defaults.update(
-            {
-                "entry_data": form.cleaned_data,
-                "html_headers": dict(
-                    user_agent=request.headers["User-Agent"],
-                    referer=request.headers["Referer"],
-                ),
-            }
-        )
+        defaults["entry_data"] = form.cleaned_data
         if keys:  # update_or_create only works if at least one key is given
             try:
                 FormEntry.objects.update_or_create(**keys, defaults=defaults)
@@ -139,7 +143,7 @@ class SaveToDBAction(FormAction):
                 FormEntry.objects.filter(**keys).delete()
                 FormEntry.objects.create(**keys, **defaults)
         else:
-            FormEntry.objects.create(**defaults), True
+            FormEntry.objects.create(**defaults)
 
 
 SAVE_TO_DB_ACTION = next(iter(_action_registry)) if _action_registry else None
@@ -220,21 +224,29 @@ class SendMailAction(FormAction):
         except TemplateDoesNotExist:
             subject = self.subject % dict(form_name=context["form_name"])
 
-        if not recipients:
-            return mail_admins(
-                subject,
-                message,
-                fail_silently=True,
-                html_message=html_message,
-            )
-        else:
-            return send_mail(
-                subject,
-                message,
-                self.from_mail,
-                recipients.split(),
-                fail_silently=True,
-                html_message=html_message,
+        # A failed email must not break the form submission for the user,
+        # but it must not go unnoticed either - hence log instead of raise.
+        try:
+            if not recipients:
+                return mail_admins(
+                    subject,
+                    message,
+                    fail_silently=False,
+                    html_message=html_message,
+                )
+            else:
+                return send_mail(
+                    subject,
+                    message,
+                    self.from_mail,
+                    recipients.split(),
+                    fail_silently=False,
+                    html_message=html_message,
+                )
+        except Exception:
+            logger.exception(
+                "Failed to send email for submission of form %s",
+                context["form_name"],
             )
 
 

--- a/djangocms_form_builder/cms_plugins/ajax_plugins.py
+++ b/djangocms_form_builder/cms_plugins/ajax_plugins.py
@@ -61,7 +61,7 @@ class AjaxFormMixin(FormMixin):
         # Execute save method
         save = getattr(form, "save", None)
         if callable(save):
-            result = form.save()
+            save()
         # Identify redirect
         redirect = get_option(form, "redirect", None)
         if isinstance(redirect, str):

--- a/djangocms_form_builder/fields.py
+++ b/djangocms_form_builder/fields.py
@@ -9,21 +9,6 @@ from . import settings
 from .helpers import first_choice
 
 
-class TemplateChoiceMixin:
-    """Mixin that hides the template field if only one template is available and is selected"""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if "template" in self.fields:
-            template_field = self.fields["template"]
-            choices = template_field.choices
-            instance = kwargs.get("instance", None)
-            if len(choices) == 1 and (
-                instance is None or instance.config.get("template", "") == choices[0][0]
-            ):
-                template_field.widget = forms.HiddenInput()
-
-
 class ButtonGroup(forms.RadioSelect):
     template_name = "djangocms_form_builder/admin/widgets/button_group.html"
     option_template_name = (
@@ -32,68 +17,6 @@ class ButtonGroup(forms.RadioSelect):
 
     class Media:
         css = {"all": ("djangocms_form_builder/css/button_group.css",)}
-
-
-class ColoredButtonGroup(ButtonGroup):
-    option_template_name = (
-        "djangocms_form_builder/admin/widgets/button_group_color_option.html"
-    )
-
-    class Media:
-        css = settings.ADMIN_CSS
-
-    def __init__(self, *args, **kwargs):
-        kwargs.update({"attrs": {**kwargs.get("attrs", {}), **dict(property="color")}})
-        super().__init__(*args, **kwargs)
-
-
-class IconGroup(ButtonGroup):
-    option_template_name = "djangocms_form_builder/admin/widgets/icon_group_option.html"
-
-    def __init__(self, *args, **kwargs):
-        kwargs.update({"attrs": {**dict(property="icon"), **kwargs.get("attrs", {})}})
-        super().__init__(*args, **kwargs)
-
-
-class IconMultiselect(forms.CheckboxSelectMultiple):
-    template_name = "djangocms_form_builder/admin/widgets/button_group.html"
-    option_template_name = "djangocms_form_builder/admin/widgets/icon_group_option.html"
-
-    class Media:
-        css = {"all": ("djangocms_form_builder/css/button_group.css",)}
-
-    def __init__(self, *args, **kwargs):
-        kwargs.update({"attrs": {**kwargs.get("attrs", {}), **dict(property="icon")}})
-        super().__init__(*args, **kwargs)
-
-
-class OptionalDeviceChoiceField(forms.MultipleChoiceField):
-    def __init__(self, **kwargs):
-        kwargs.setdefault("choices", settings.DEVICE_CHOICES)
-        kwargs.setdefault("initial", None)
-        kwargs.setdefault("widget", IconMultiselect())
-        super().__init__(**kwargs)
-
-    def prepare_value(self, value):
-        if value is None:
-            value = [size for size, _ in settings.DEVICE_CHOICES]
-        return super().prepare_value(value)
-
-    def clean(self, value):
-        value = super().clean(value)
-        if len(value) == len(settings.DEVICE_CHOICES):
-            return None
-        return value
-
-
-class DeviceChoiceField(OptionalDeviceChoiceField):
-    def clean(self, value):
-        value = super().clean(value)
-        if isinstance(value, list) and len(value) == 0:
-            raise ValidationError(
-                _("Please select at least one device size"), code="invalid"
-            )
-        return value
 
 
 class AttributesField(fields.AttributesField):
@@ -155,6 +78,7 @@ class ChoicesFormField(fields.AttributesFormField):
         return super().prepare_value({key: value for key, value in value})
 
 
+# Kept because it is referenced by migration 0001 - do not use in new code.
 class TagTypeField(models.CharField):
     def __init__(self, *args, **kwargs):
         if "verbose_name" not in kwargs:
@@ -167,14 +91,4 @@ class TagTypeField(models.CharField):
             kwargs["max_length"] = 255
         if "help_text" not in kwargs:
             kwargs["help_text"] = _("Select the HTML tag to be used.")
-        super().__init__(*args, **kwargs)
-
-
-class TagTypeFormField(forms.ChoiceField):
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault("label", _("Tag type"))
-        kwargs.setdefault("choices", settings.TAG_CHOICES)
-        kwargs.setdefault("initial", first_choice(settings.TAG_CHOICES))
-        kwargs.setdefault("required", False)
-        kwargs.setdefault("widget", ButtonGroup(attrs=dict(property="text")))
         super().__init__(*args, **kwargs)

--- a/djangocms_form_builder/forms.py
+++ b/djangocms_form_builder/forms.py
@@ -18,14 +18,6 @@ from .fields import AttributesFormField, ButtonGroup, ChoicesFormField
 from .helpers import get_option, mark_safe_lazy
 
 
-class Noop:
-    pass
-
-
-def mixin_factory(x):
-    return Noop
-
-
 class SimpleFrontendForm(forms.Form):
     takes_request = True
 
@@ -73,7 +65,7 @@ class SelectMultipleActionsWidget(forms.CheckboxSelectMultiple):
         return super().format_value(value)
 
 
-class FormsForm(mixin_factory("Form"), EntangledModelForm):
+class FormsForm(EntangledModelForm):
     """
     Components > "Forms" Plugin
     https://getbootstrap.com/docs/5.1/forms/overview/
@@ -243,7 +235,7 @@ class FormsForm(mixin_factory("Form"), EntangledModelForm):
                             ),
                         }
                     )
-        elif not self.cleaned_data["form_selection"]:
+        elif not self.cleaned_data.get("form_selection"):
             raise ValidationError(
                 {
                     "form_actions": _(
@@ -267,10 +259,6 @@ class FormsForm(mixin_factory("Form"), EntangledModelForm):
             )
         return self.cleaned_data
 
-    def is_valid(self):
-        valid = super().is_valid()
-        return valid
-
 
 FORBIDDEN_FORM_NAMES = [
     "Meta",
@@ -278,7 +266,7 @@ FORBIDDEN_FORM_NAMES = [
     "form_name",
     "form_user",
     "entry_data",
-    "html_header",
+    "html_headers",
 ] + dir(SimpleFrontendForm(request=None))
 
 
@@ -343,7 +331,7 @@ class FormFieldMixin(EntangledModelFormMixin):
     )
 
 
-class CharFieldForm(mixin_factory("CharField"), FormFieldMixin, EntangledModelForm):
+class CharFieldForm(FormFieldMixin, EntangledModelForm):
     class Meta:
         model = models.FormField
         entangled_fields = {
@@ -365,21 +353,19 @@ class CharFieldForm(mixin_factory("CharField"), FormFieldMixin, EntangledModelFo
     )
 
 
-class EmailFieldForm(mixin_factory("EmailField"), FormFieldMixin, EntangledModelForm):
+class EmailFieldForm(FormFieldMixin, EntangledModelForm):
     class Meta:
         model = models.FormField
         entangled_fields = {"config": []}
 
 
-class UrlFieldForm(mixin_factory("URLField"), FormFieldMixin, EntangledModelForm):
+class UrlFieldForm(FormFieldMixin, EntangledModelForm):
     class Meta:
         model = models.FormField
         entangled_fields = {"config": []}
 
 
-class DecimalFieldForm(
-    mixin_factory("DecimalField"), FormFieldMixin, EntangledModelForm
-):
+class DecimalFieldForm(FormFieldMixin, EntangledModelForm):
     class Meta:
         model = models.FormField
         entangled_fields = {
@@ -406,9 +392,7 @@ class DecimalFieldForm(
     )
 
 
-class IntegerFieldForm(
-    mixin_factory("IntegerField"), FormFieldMixin, EntangledModelForm
-):
+class IntegerFieldForm(FormFieldMixin, EntangledModelForm):
     class Meta:
         model = models.FormField
         entangled_fields = {
@@ -428,9 +412,7 @@ class IntegerFieldForm(
     )
 
 
-class TextareaFieldForm(
-    mixin_factory("TextareaField"), FormFieldMixin, EntangledModelForm
-):
+class TextareaFieldForm(FormFieldMixin, EntangledModelForm):
     class Meta:
         model = models.FormField
         entangled_fields = {
@@ -460,7 +442,7 @@ class TextareaFieldForm(
     )
 
 
-class DateFieldForm(mixin_factory("DateField"), FormFieldMixin, EntangledModelForm):
+class DateFieldForm(FormFieldMixin, EntangledModelForm):
     class Meta:
         model = models.FormField
         entangled_fields = {"config": []}
@@ -470,9 +452,7 @@ class DateFieldForm(mixin_factory("DateField"), FormFieldMixin, EntangledModelFo
         self.fields["field_placeholder"].help_text = _("Not visible on most browsers.")
 
 
-class DateTimeFieldForm(
-    mixin_factory("DateTimeField"), FormFieldMixin, EntangledModelForm
-):
+class DateTimeFieldForm(FormFieldMixin, EntangledModelForm):
     class Meta:
         model = models.FormField
         entangled_fields = {"config": []}
@@ -482,7 +462,7 @@ class DateTimeFieldForm(
         self.fields["field_placeholder"].help_text = _("Not visible on most browsers.")
 
 
-class TimeFieldForm(mixin_factory("TimeField"), FormFieldMixin, EntangledModelForm):
+class TimeFieldForm(FormFieldMixin, EntangledModelForm):
     class Meta:
         model = models.FormField
         entangled_fields = {"config": []}
@@ -492,7 +472,7 @@ class TimeFieldForm(mixin_factory("TimeField"), FormFieldMixin, EntangledModelFo
         self.fields["field_placeholder"].help_text = _("Not visible on most browsers.")
 
 
-class SelectFieldForm(mixin_factory("SelectField"), FormFieldMixin, EntangledModelForm):
+class SelectFieldForm(FormFieldMixin, EntangledModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if "instance" in kwargs and kwargs["instance"] is not None:
@@ -561,9 +541,7 @@ class ChoiceForm(EntangledModelForm):
     )
 
 
-class BooleanFieldForm(
-    mixin_factory("BooleanField"), FormFieldMixin, EntangledModelForm
-):
+class BooleanFieldForm(FormFieldMixin, EntangledModelForm):
     class Meta:
         model = models.FormField
         entangled_fields = {
@@ -590,9 +568,7 @@ class BooleanFieldForm(
         )
 
 
-class SubmitButtonForm(
-    mixin_factory("SubmitButton"), FormFieldMixin, EntangledModelForm
-):
+class SubmitButtonForm(FormFieldMixin, EntangledModelForm):
     class Meta:
         model = models.FormField
         entangled_fields = {

--- a/djangocms_form_builder/helpers.py
+++ b/djangocms_form_builder/helpers.py
@@ -1,10 +1,6 @@
 import copy
 import decimal
 
-from django.apps import apps
-from django.db.models import ObjectDoesNotExist
-from django.template.exceptions import TemplateDoesNotExist
-from django.template.loader import select_template
 from django.utils.functional import lazy
 from django.utils.safestring import mark_safe
 
@@ -16,18 +12,6 @@ global_options = settings.FORM_OPTIONS
 def get_option(form, option, default=None):
     form_options = getattr(getattr(form, "Meta", None), "options", {})
     return form_options.get(option, global_options.get(option, default))
-
-
-def get_related_object(scope, field_name):
-    """
-    Returns the related field, referenced by the content of a ModelChoiceField.
-    """
-    try:
-        Model = apps.get_model(scope[field_name]["model"])
-        relobj = Model.objects.get(pk=scope[field_name]["pk"])
-    except (ObjectDoesNotExist, LookupError):
-        relobj = None
-    return relobj
 
 
 def insert_fields(
@@ -84,25 +68,6 @@ def first_choice(choices):
             if first is not None:
                 return first
     return None
-
-
-def get_template_path(prefix, template, name):
-    return (
-        f"djangocms_form_builder/{settings.framework}/{prefix}/{template}/{name}.html"
-    )
-
-
-def get_plugin_template(instance, prefix, name, templates):
-    template = getattr(instance, "template", first_choice(templates))
-    template_path = get_template_path(prefix, template, name)
-
-    try:
-        select_template([template_path])
-    except TemplateDoesNotExist:
-        # TODO render a warning inside the template
-        template_path = get_template_path(prefix, "default", name)
-
-    return template_path
 
 
 # use mark_safe_lazy to delay the translation when using mark_safe

--- a/djangocms_form_builder/management/commands/prune_form_entries.py
+++ b/djangocms_form_builder/management/commands/prune_form_entries.py
@@ -1,0 +1,48 @@
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
+
+from djangocms_form_builder.entry_model import FormEntry
+
+
+class Command(BaseCommand):
+    help = (
+        "Delete form entries that have not been updated for a given number of "
+        "days. Use this to enforce a retention policy for personal data "
+        "collected through forms."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--days",
+            type=int,
+            required=True,
+            help="Delete entries last updated more than DAYS days ago.",
+        )
+        parser.add_argument(
+            "--form-name",
+            default=None,
+            help="Only delete entries submitted to the form with this name.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Only report how many entries would be deleted.",
+        )
+
+    def handle(self, *args, **options):
+        days = options["days"]
+        if days < 0:
+            raise CommandError("--days must not be negative.")
+        cutoff = timezone.now() - timedelta(days=days)
+        entries = FormEntry.objects.filter(entry_updated_at__lt=cutoff)
+        if options["form_name"]:
+            entries = entries.filter(form_name=options["form_name"])
+        count = entries.count()
+        noun = "form entry" if count == 1 else "form entries"
+        if options["dry_run"]:
+            self.stdout.write(f"Would delete {count} {noun}.")
+            return
+        entries.delete()
+        self.stdout.write(self.style.SUCCESS(f"Deleted {count} {noun}."))

--- a/djangocms_form_builder/migrations/0005_static_captcha_schema.py
+++ b/djangocms_form_builder/migrations/0005_static_captcha_schema.py
@@ -1,0 +1,57 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Make the schema independent of which captcha packages are installed.
+
+    Previously ``captcha_requirement.null`` and the ``captcha_widget`` default
+    and choices depended on the apps installed when migrations were generated,
+    causing spurious migrations in user projects.
+    """
+
+    dependencies = [
+        ("djangocms_form_builder", "0004_alter_form_captcha_requirement_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="datetimefield",
+            options={"verbose_name": "Date and time field"},
+        ),
+        migrations.AlterModelOptions(
+            name="timefield",
+            options={"verbose_name": "Time field"},
+        ),
+        migrations.AlterField(
+            model_name="form",
+            name="captcha_requirement",
+            field=models.DecimalField(
+                decimal_places=2,
+                default=0.5,
+                help_text="Only for reCaptcha v3: Minimum score required to accept challenge.",
+                max_digits=3,
+                null=True,
+                verbose_name="Minimum score requirement",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="form",
+            name="captcha_widget",
+            field=models.CharField(
+                blank=True,
+                default="",
+                help_text='Read more in the <a href="https://developers.google.com/recaptcha" target="_blank">documentation</a>.',
+                max_length=16,
+                verbose_name="captcha widget",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="form",
+            name="form_spacing",
+            field=models.CharField(
+                blank=True,
+                max_length=16,
+                verbose_name="Margin between fields",
+            ),
+        ),
+    ]

--- a/djangocms_form_builder/models.py
+++ b/djangocms_form_builder/models.py
@@ -5,12 +5,10 @@ from django import forms
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core.validators import validate_slug
 from django.db import models
-from django.forms.widgets import Input
 from django.utils.html import conditional_escape, mark_safe
 from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 
-from . import recaptcha, settings
 from .entry_model import FormEntry  # NoQA
 from .fields import AttributesField
 from .helpers import coerce_decimal, coerce_int, mark_safe_lazy
@@ -58,6 +56,7 @@ class Form(CMSPlugin):
     form_spacing = models.CharField(
         verbose_name=_("Margin between fields"),
         max_length=16,
+        blank=True,
     )
 
     form_actions = models.CharField(
@@ -75,12 +74,13 @@ class Form(CMSPlugin):
 
     attributes = AttributesField()
 
+    # Keep the schema independent of which captcha packages happen to be
+    # installed - choices and defaults are enforced at the form level.
     captcha_widget = models.CharField(
         verbose_name=_("captcha widget"),
         max_length=16,
         blank=True,
-        default=recaptcha.CAPTCHA_CHOICES[0][0] if recaptcha.installed else "",
-        choices=settings.EMPTY_CHOICE + recaptcha.CAPTCHA_CHOICES,
+        default="",
         help_text=mark_safe_lazy(
             _(
                 'Read more in the <a href="{link}" target="_blank">documentation</a>.'
@@ -89,7 +89,7 @@ class Form(CMSPlugin):
     )
     captcha_requirement = models.DecimalField(
         verbose_name=_("Minimum score requirement"),
-        null=not recaptcha.installed,
+        null=True,
         decimal_places=2,
         max_digits=3,
         default=0.5,
@@ -165,11 +165,13 @@ class FormField(CMSPlugin):
         classes.update(self._additional_classes)
         if classes:
             attributes["class"] = " ".join(classes)
-        parts = (
-            f'{item}="{conditional_escape(value)}"' if value else f"{item}"
+        parts = " ".join(
+            f'{conditional_escape(item)}="{conditional_escape(value)}"'
+            if value
+            else conditional_escape(item)
             for item, value in attributes.items()
         )
-        return mark_safe(" " + " ".join(parts)) if parts else ""
+        return mark_safe(" " + parts) if parts else ""
 
     def save(self, *args, **kwargs):
         self.ui_item = self.__class__.__name__
@@ -350,7 +352,7 @@ class DateField(FormField):
 class DateTimeField(FormField):
     class Meta:
         proxy = True
-        verbose_name = _("Date field")
+        verbose_name = _("Date and time field")
 
     class DateTimeField(forms.DateTimeField):
         def prepare_value(self, value):
@@ -377,7 +379,7 @@ class DateTimeField(FormField):
 class TimeField(FormField):
     class Meta:
         proxy = True
-        verbose_name = _("Date field")
+        verbose_name = _("Time field")
 
     class TimeInput(forms.TimeInput):
         input_type = "time"
@@ -451,6 +453,8 @@ class Choice(FormField):
 
 
 class SwitchInput(forms.CheckboxInput):
+    # The class name is significant: the frontend attr_dict maps widget class
+    # names to CSS classes, rendering this as a switch instead of a checkbox.
     pass
 
 
@@ -468,10 +472,6 @@ class BooleanField(FormField):
             if self.config.get("field_as_switch", False)
             else forms.CheckboxInput(),
         )
-
-
-class FormSubmitButton(forms.Field):
-    widget = Input(attrs=dict(type="submit"))
 
 
 class SubmitButton(FormField):

--- a/djangocms_form_builder/recaptcha.py
+++ b/djangocms_form_builder/recaptcha.py
@@ -49,24 +49,20 @@ else:
 
 
 def get_recaptcha_field(instance):
-    config = instance.captcha_config
+    config = instance.captcha_config or {}
     widget_params = {
         "attrs": {
-            key: value
-            for key, value in config.get("captcha_config", {}).items()
-            if key.startswith("data-")
+            key: value for key, value in config.items() if key.startswith("data-")
         },
         "api_params": {
-            key: value
-            for key, value in config.get("captcha_config", {}).items()
-            if not key.startswith("data-")
+            key: value for key, value in config.items() if not key.startswith("data-")
         },
     }
     widget_params["attrs"]["no_field_sep"] = True
-    if config.get("captcha_widget", "") == "v3":
+    if instance.captcha_widget == "v3":
         widget_params["attrs"]["required_score"] = coerce_decimal(
-            config.get("captcha_requirement", 0.5)
-        )  # installing recaptcha 3 ?
+            instance.captcha_requirement
+        )
     if not widget_params["api_params"]:
         del widget_params["api_params"]
 

--- a/djangocms_form_builder/recaptcha.py
+++ b/djangocms_form_builder/recaptcha.py
@@ -61,7 +61,7 @@ def get_recaptcha_field(instance):
     widget_params["attrs"]["no_field_sep"] = True
     if instance.captcha_widget == "v3":
         widget_params["attrs"]["required_score"] = coerce_decimal(
-            instance.captcha_requirement
+            0.5 if instance.captcha_requirement is None else instance.captcha_requirement
         )
     if not widget_params["api_params"]:
         del widget_params["api_params"]

--- a/djangocms_form_builder/recaptcha.py
+++ b/djangocms_form_builder/recaptcha.py
@@ -61,7 +61,9 @@ def get_recaptcha_field(instance):
     widget_params["attrs"]["no_field_sep"] = True
     if instance.captcha_widget == "v3":
         widget_params["attrs"]["required_score"] = coerce_decimal(
-            0.5 if instance.captcha_requirement is None else instance.captcha_requirement
+            "0.5"
+            if instance.captcha_requirement is None
+            else instance.captcha_requirement
         )
     if not widget_params["api_params"]:
         del widget_params["api_params"]

--- a/djangocms_form_builder/settings.py
+++ b/djangocms_form_builder/settings.py
@@ -5,13 +5,6 @@ from django.utils.translation import gettext_lazy as _
 
 EMPTY_CHOICE = (("", "-----"),)
 
-ADMIN_CSS = getattr(
-    django_settings,
-    "DJANGOCMS_FRONTEND_ADMIN_CSS",
-    {},
-)
-
-
 FORM_OPTIONS = getattr(django_settings, "DJANGOCMS_FORMS_OPTIONS", {})
 MAIL_TEMPLATE_SETS = getattr(
     django_settings, "DJANGOCMS_MAIL_TEMPLATE_SETS", (("default", _("Default")),)
@@ -29,7 +22,6 @@ FORM_TEMPLATE = getattr(
 )
 
 theme_render_path = f"{theme}.frameworks.{framework}"
-theme_forms_path = f"{theme}.forms"
 
 if not getattr(django_settings, "DJANGO_FORM_BUILDER_SPACER_CHOICES", False):
     if not getattr(django_settings, "DJANGOCMS_FRONTEND_SPACER_SIZES", False):
@@ -77,12 +69,4 @@ def get_renderer(my_module):
         my_module = my_module.__name__
     return get_mixins(
         "{name}RenderMixin", theme_render_path, f"{my_module}.frameworks.{framework}"
-    )
-
-
-def get_forms(my_module):
-    if not isinstance(my_module, str):
-        my_module = my_module.__name__
-    return get_mixins(
-        "{name}FormMixin", theme_forms_path, f"{my_module}.frameworks.{framework}"
     )

--- a/djangocms_form_builder/templatetags/form_builder_tags.py
+++ b/djangocms_form_builder/templatetags/form_builder_tags.py
@@ -1,7 +1,7 @@
 from django import template
 from django.apps import apps
 from django.template.loader import render_to_string
-from django.utils.html import mark_safe
+from django.utils.html import conditional_escape, mark_safe
 
 from .. import constants, recaptcha
 from ..helpers import get_option
@@ -96,7 +96,10 @@ def render_widget(form, form_field, **kwargs):
     label_attr = attrs_for_widget(field.field.widget, "label")
     if field.help_text:
         widget_attr.update({"aria-describedby": f"hints_{field.id_for_label}"})
-        help_text = f'<div id="hints_{field.id_for_label}" class="form-text">{field.help_text}</div>'
+        help_text = (
+            f'<div id="hints_{field.id_for_label}" class="form-text">'
+            f"{conditional_escape(field.help_text)}</div>"
+        )
     else:
         help_text = ""
     input_type = getattr(field.field.widget, "input_type", None)
@@ -110,7 +113,8 @@ def render_widget(form, form_field, **kwargs):
     div_attrs = " ".join([f'{key}="{value}"' for key, value in div_attrs.items()])
     grp_attrs = attrs_for_widget(field.field.widget, "group")
     errors = "".join(
-        f'<div class="invalid-feedback">{error}</div>' for error in field.errors
+        f'<div class="invalid-feedback">{conditional_escape(error)}</div>'
+        for error in field.errors
     )
     if field.field.widget.template_name.rsplit("/", 1)[-1] in (
         "radio.html",

--- a/djangocms_form_builder/views.py
+++ b/djangocms_form_builder/views.py
@@ -2,11 +2,10 @@ import hashlib
 
 from cms import __version__ as cms_version
 from cms.models import CMSPlugin
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.http import Http404, JsonResponse, QueryDict
 from django.shortcuts import get_object_or_404
 from django.utils.crypto import get_random_string
-from django.utils.translation import gettext as _
 from django.views import View
 
 _formview_pool = {}
@@ -27,9 +26,10 @@ def register_form_view(cls, slug=None):
     if not slug:
         slug = get_random_string(length=12)
     key = hashlib.sha384(slug.encode("utf-8")).hexdigest()
-    if key in _formview_pool:
-        assert _formview_pool[key][0] == cls, _(
-            "Only unique slugs accepted for form views"
+    if key in _formview_pool and _formview_pool[key][0] is not cls:
+        raise ImproperlyConfigured(
+            f"Only unique slugs accepted for form views: {slug!r} is already "
+            f"registered for {_formview_pool[key][0]!r}"
         )
     _formview_pool[key] = (cls, slug, key)
     return key

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -98,6 +98,41 @@ class ActionTestCase(TestFixture, CMSTestCase):
         self.assertEqual(args[0], "Test form form submission")
         self.assertIn("Form submission", args[1])
 
+    def test_send_mail_action_logs_failures(self):
+        plugin_instance = add_plugin(
+            placeholder=self.placeholder,
+            plugin_type="FormPlugin",
+            language=self.language,
+            form_name="test_form",
+        )
+        plugin_instance.action_parameters = {
+            "sendemail_recipients": "a@b.c",
+            "sendemail_template": "default",
+        }
+        plugin_instance.form_actions = f'["{self.send_mail_action}"]'
+        plugin_instance.save()
+
+        child_plugin = add_plugin(
+            placeholder=self.placeholder,
+            plugin_type="CharFieldPlugin",
+            language=self.language,
+            target=plugin_instance,
+            config={"field_name": "field1"},
+        )
+        child_plugin.save()
+        plugin_instance.child_plugin_instances = [child_plugin]
+        child_plugin.child_plugin_instances = []
+
+        plugin = plugin_instance.get_plugin_class_instance()
+        plugin.instance = plugin_instance
+
+        with patch("django.core.mail.send_mail", side_effect=Exception("SMTP down")):
+            form = plugin.get_form_class()({}, request=self.get_request("/"))
+            form.cleaned_data = {"field1": "value1"}
+            # The submission must not raise, but the failure must be logged
+            with self.assertLogs("djangocms_form_builder.actions", level="ERROR"):
+                form.save()
+
     def test_send_mail_action_authenticated_user(self):
         user = get_user_model().objects.create_user(
             username="johndoe",
@@ -148,7 +183,7 @@ class ActionTestCase(TestFixture, CMSTestCase):
         self.assertIn("John Doe (johndoe)", args[1])
         self.assertNotIn("anonymous", args[1])
 
-    def test_save_to_db_action_creates_entry_with_headers(self):
+    def test_save_to_db_action_creates_entry(self):
         plugin_instance = add_plugin(
             placeholder=self.placeholder,
             plugin_type="FormPlugin",
@@ -187,8 +222,8 @@ class ActionTestCase(TestFixture, CMSTestCase):
         self.assertEqual(entry.form_name, "save_form")
         self.assertEqual(entry.form_user, None)
         self.assertEqual(entry.entry_data.get("field1"), "value1")
-        self.assertEqual(entry.html_headers.get("user_agent"), "pytest-agent")
-        self.assertEqual(entry.html_headers.get("referer"), "/from")
+        # Request headers (User-Agent, Referer) are deliberately not stored
+        self.assertEqual(entry.html_headers, {})
 
     def test_save_to_db_action_unique_updates_single_entry(self):
         plugin_instance = add_plugin(

--- a/tests/test_ajax_plugin.py
+++ b/tests/test_ajax_plugin.py
@@ -5,6 +5,7 @@ from urllib.parse import urlencode
 from cms import __version__ as cms_version
 from cms.api import add_plugin
 from cms.test_utils.testcases import CMSTestCase
+from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponseNotAllowed, JsonResponse
 from django.test import RequestFactory, override_settings
 from django.urls import reverse
@@ -466,7 +467,7 @@ class RegisterFormViewTestCase(CMSTestCase):
 
         register_form_view(FormView1, slug="conflicting-slug")
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ImproperlyConfigured):
             register_form_view(FormView2, slug="conflicting-slug")
 
 

--- a/tests/test_form_rendering.py
+++ b/tests/test_form_rendering.py
@@ -1,5 +1,7 @@
 import re
+from decimal import Decimal
 from unittest import skipIf
+from unittest.mock import patch
 
 from cms import __version__ as cms_version
 from cms.api import add_plugin
@@ -336,6 +338,37 @@ class TemplateTagsTestCase(CMSTestCase):
         self.assertIn("invalid-feedback", rendered)
         self.assertIn("is_invalid", rendered)
 
+    def test_render_widget_escapes_help_text(self):
+        template = Template(
+            "{% load form_builder_tags %}{% render_widget form 'name' %}"
+        )
+
+        class TestForm(forms.Form):
+            name = forms.CharField(help_text='<script>alert("xss")</script>')
+
+        rendered = template.render(Context({"form": TestForm()}))
+
+        self.assertIn("&lt;script&gt;", rendered)
+        self.assertNotIn("<script>", rendered)
+
+    def test_render_widget_escapes_validation_errors(self):
+        template = Template(
+            "{% load form_builder_tags %}{% render_widget form 'name' %}"
+        )
+
+        class TestForm(forms.Form):
+            name = forms.CharField()
+
+            def clean_name(self):
+                raise forms.ValidationError('<script>alert("xss")</script>')
+
+        form = TestForm(data={"name": "unsafe"})
+        self.assertFalse(form.is_valid())
+        rendered = template.render(Context({"form": form}))
+
+        self.assertIn("&lt;script&gt;", rendered)
+        self.assertNotIn("<script>", rendered)
+
     def test_add_placeholder_filter(self):
         """Test {% add_placeholder %} filter"""
         template = Template("{% load form_builder_tags %}{{ form|add_placeholder }}")
@@ -405,6 +438,36 @@ class AltchaIntegrationTestCase(TestFixture, CMSTestCase):
         )()
         field = recaptcha.get_recaptcha_field(instance)
         self.assertIsInstance(field, AltchaField)
+
+    def test_recaptcha_v3_defaults_missing_requirement(self):
+        class DummyWidget:
+            def __init__(self, **kwargs):
+                self.options = kwargs
+
+        class DummyField:
+            def __init__(self, **kwargs):
+                self.widget = kwargs["widget"]
+
+        instance = type(
+            "MockInstance",
+            (),
+            {
+                "captcha_widget": "v3",
+                "captcha_config": None,
+                "captcha_requirement": None,
+            },
+        )()
+
+        with (
+            patch.dict(recaptcha.CAPTCHA_WIDGETS, {"v3": DummyWidget}),
+            patch.dict(recaptcha.CAPTCHA_FIELDS, {"v3": DummyField}),
+        ):
+            field = recaptcha.get_recaptcha_field(instance)
+
+        self.assertEqual(
+            field.widget.options["attrs"]["required_score"], Decimal("0.5")
+        )
+        self.assertNotIn("api_params", field.widget.options)
 
 
 class FormSubmissionRenderingTestCase(TestFixture, CMSTestCase):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,12 +1,8 @@
 from decimal import Decimal
-from types import SimpleNamespace
-from unittest.mock import patch
 
-from django.db.models import ObjectDoesNotExist
 from django.test import SimpleTestCase
 
 from djangocms_form_builder import helpers
-from djangocms_form_builder import settings as app_settings
 
 
 class HelpersTests(SimpleTestCase):
@@ -39,41 +35,6 @@ class HelpersTests(SimpleTestCase):
             helpers.get_option(DummyForm, "missing", default="dflt"), "dflt"
         )
 
-    def test_get_related_object_success_and_fail(self):
-        # Fake model and manager
-        class Manager:
-            def __init__(self, store):
-                self._store = store
-
-            def get(self, pk):
-                if pk in self._store:
-                    return self._store[pk]
-                raise ObjectDoesNotExist()
-
-        class FakeModel:
-            objects = Manager({1: SimpleNamespace(pk=1), 2: SimpleNamespace(pk=2)})
-
-        with patch(
-            "djangocms_form_builder.helpers.apps.get_model", return_value=FakeModel
-        ):
-            scope = {"target": {"model": "app.Label", "pk": 1}}
-            obj = helpers.get_related_object(scope, "target")
-            self.assertIsNotNone(obj)
-            self.assertEqual(obj.pk, 1)
-
-            scope_fail = {"target": {"model": "app.Label", "pk": 9}}
-            obj2 = helpers.get_related_object(scope_fail, "target")
-            self.assertIsNone(obj2)
-
-        # Also ensure LookupError path returns None
-        with patch(
-            "djangocms_form_builder.helpers.apps.get_model", side_effect=LookupError
-        ):
-            obj3 = helpers.get_related_object(
-                {"target": {"model": "x", "pk": 1}}, "target"
-            )
-            self.assertIsNone(obj3)
-
     def test_insert_fields_appends_new_block_when_block_none(self):
         fieldsets = [("Main", {"fields": ["a", "b"]})]
         fs = helpers.insert_fields(
@@ -99,29 +60,6 @@ class HelpersTests(SimpleTestCase):
         choices = (("group", (("a", "A"), ("b", "B"))), ("c", "C"))
         self.assertEqual(helpers.first_choice(choices), "a")
         self.assertEqual(helpers.first_choice((("x", "X"),)), "x")
-
-    def test_get_template_path(self):
-        path = helpers.get_template_path("render", "default", "form")
-        self.assertEqual(
-            path,
-            f"djangocms_form_builder/{app_settings.framework}/render/default/form.html",
-        )
-
-    def test_get_plugin_template_existing_and_fallback(self):
-        class Inst:
-            # no explicit template, will use first_choice from choices below
-            pass
-
-        choices = (("default", "Default"), ("fancy", "Fancy"))
-
-        # Existing
-        path = helpers.get_plugin_template(Inst(), "render", "form", choices)
-        self.assertTrue(path.endswith("/render/default/form.html"))
-
-        # Non-existing should fallback to default
-        inst2 = SimpleNamespace(template="does-not-exist")
-        path2 = helpers.get_plugin_template(inst2, "render", "form", choices)
-        self.assertTrue(path2.endswith("/render/default/form.html"))
 
     def test_mark_safe_lazy(self):
         s = helpers.mark_safe_lazy("<b>hi</b>")

--- a/tests/test_prune_command.py
+++ b/tests/test_prune_command.py
@@ -1,0 +1,54 @@
+from datetime import timedelta
+from io import StringIO
+
+from django.core.management import CommandError, call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from djangocms_form_builder.entry_model import FormEntry
+
+
+class PruneFormEntriesCommandTestCase(TestCase):
+    def setUp(self):
+        # auto_now is bypassed by queryset .update(), so entries can be
+        # backdated after creation
+        old_contact = FormEntry.objects.create(
+            form_name="contact", entry_data={"field": "old"}
+        )
+        old_other = FormEntry.objects.create(
+            form_name="other", entry_data={"field": "old"}
+        )
+        FormEntry.objects.filter(pk__in=[old_contact.pk, old_other.pk]).update(
+            entry_updated_at=timezone.now() - timedelta(days=40)
+        )
+        FormEntry.objects.create(form_name="contact", entry_data={"field": "new"})
+
+    def call(self, *args):
+        out = StringIO()
+        call_command("prune_form_entries", *args, stdout=out)
+        return out.getvalue()
+
+    def test_prune_deletes_old_entries_only(self):
+        output = self.call("--days", "30")
+        self.assertIn("Deleted 2 form entries.", output)
+        self.assertEqual(FormEntry.objects.count(), 1)
+        self.assertEqual(FormEntry.objects.get().entry_data, {"field": "new"})
+
+    def test_dry_run_deletes_nothing(self):
+        output = self.call("--days", "30", "--dry-run")
+        self.assertIn("Would delete 2 form entries.", output)
+        self.assertEqual(FormEntry.objects.count(), 3)
+
+    def test_form_name_filter(self):
+        output = self.call("--days", "30", "--form-name", "contact")
+        self.assertIn("Deleted 1 form entry.", output)
+        self.assertEqual(FormEntry.objects.count(), 2)
+        self.assertFalse(
+            FormEntry.objects.filter(
+                form_name="contact", entry_data={"field": "old"}
+            ).exists()
+        )
+
+    def test_negative_days_rejected(self):
+        with self.assertRaises(CommandError):
+            self.call("--days", "-1")


### PR DESCRIPTION
## Summary by Sourcery

Harden public form handling, improve data retention and privacy controls, and decouple schema and behavior from optional integrations and theme mixins.

New Features:
- Add a prune_form_entries management command to enforce time-based retention of stored form submissions, with optional form-name scoping and dry-run support.
- Provide an in-package HTMLFormField fallback when djangocms-text is not installed so forms continue to work without that dependency.

Bug Fixes:
- Stop persisting request headers such as User-Agent and Referer in saved form entries to avoid leaking client metadata.
- Ensure send-mail actions do not break form submissions on email delivery failures by raising, instead logging the exception while still surfacing configuration issues via non-silent mail calls.
- Avoid KeyError in form cleaning when form_selection is absent by using a safe lookup.
- Correct FormEntry creation in the save-to-DB action to avoid returning an unintended tuple.
- Escape form field help text and validation errors when rendering widgets to prevent HTML injection in form output.
- Use the correct internal field name html_headers and fix DateTime and Time field verbose names for consistency.
- Raise ImproperlyConfigured instead of asserting when duplicate AJAX form view slugs are registered.

Enhancements:
- Make captcha-related model fields independent of installed captcha packages and adjust runtime recaptcha configuration to read from the form instance instead of nested config, stabilizing migrations and configuration handling.
- Allow blank values for form_spacing and generate HTML attribute strings using proper escaping of attribute names and values.
- Clarify semantics of SwitchInput and TagTypeField through comments to document their significance and legacy usage.
- Simplify form and field admin forms by removing unused mixin hooks, template, device-choice and tag-type helpers and tests, and obsolete theme form mixin utilities.
- Ensure AJAX form plugins call save without relying on a return value, and adjust template rendering to respect ARIA attributes while maintaining accessibility semantics.

Tests:
- Extend action tests to cover email failure logging and the updated save-to-DB behavior, including absence of stored request headers.
- Add tests for the prune_form_entries management command covering deletion behavior, dry-run mode, form-name filtering, and validation of the days argument.
- Update AJAX plugin tests to assert the new ImproperlyConfigured error on duplicate form view slugs and align with the adjusted save behavior.
- Clean up helper tests to match the removal of deprecated template and related-object utilities.