### PR TITLE
feat: Add Captcha form element plugin

### DIFF
--- a/djangocms_form_builder/cms_plugins/__init__.py
+++ b/djangocms_form_builder/cms_plugins/__init__.py
@@ -2,6 +2,7 @@ from . import legacy  # noqa F401
 from .ajax_plugins import FormPlugin
 from .form_plugins import (
     BooleanFieldPlugin,
+    CaptchaPlugin,
     CharFieldPlugin,
     ChoicePlugin,
     DateFieldPlugin,
@@ -19,6 +20,7 @@ from .form_plugins import (
 __all__ = [
     "FormPlugin",
     "BooleanFieldPlugin",
+    "CaptchaPlugin",
     "CharFieldPlugin",
     "ChoicePlugin",
     "DateFieldPlugin",

--- a/djangocms_form_builder/cms_plugins/ajax_plugins.py
+++ b/djangocms_form_builder/cms_plugins/ajax_plugins.py
@@ -233,8 +233,10 @@ class CMSAjaxForm(AjaxFormMixin, CMSAjaxBase):
             return False
 
         def has_captcha_plugin(plugins):
+            from .form_plugins import CaptchaPlugin
+
             for child in plugins:
-                if child.plugin_type == "CaptchaPlugin":
+                if child.plugin_type == CaptchaPlugin.__name__:
                     return True
                 child_plugins = getattr(child, "child_plugin_instances", None) or []
                 if has_captcha_plugin(child_plugins):

--- a/djangocms_form_builder/cms_plugins/ajax_plugins.py
+++ b/djangocms_form_builder/cms_plugins/ajax_plugins.py
@@ -250,7 +250,6 @@ class CMSAjaxForm(AjaxFormMixin, CMSAjaxBase):
                 "has_captcha_plugin": has_captcha_plugin(
                     instance.child_plugin_instances
                 ),
-                "captcha_widget": instance.captcha_widget,
                 "csrf_cookie_httponly": django_settings.CSRF_COOKIE_HTTPONLY,
             }
         )

--- a/djangocms_form_builder/cms_plugins/ajax_plugins.py
+++ b/djangocms_form_builder/cms_plugins/ajax_plugins.py
@@ -232,12 +232,25 @@ class CMSAjaxForm(AjaxFormMixin, CMSAjaxBase):
                     return True
             return False
 
+        def has_captcha_plugin(plugins):
+            for child in plugins:
+                if child.plugin_type == "CaptchaPlugin":
+                    return True
+                child_plugins = getattr(child, "child_plugin_instances", None) or []
+                if has_captcha_plugin(child_plugins):
+                    return True
+            return False
+
         context.update(
             {
                 "instance": instance,
                 "form": form,
                 "uid": f"{instance.id}{getattr(form, 'slug', '')}-{context['form_counter']}",
                 "has_submit_button": has_submit_button(instance.child_plugin_instances),
+                "has_captcha_plugin": has_captcha_plugin(
+                    instance.child_plugin_instances
+                ),
+                "captcha_widget": instance.captcha_widget,
                 "csrf_cookie_httponly": django_settings.CSRF_COOKIE_HTTPONLY,
             }
         )

--- a/djangocms_form_builder/cms_plugins/form_plugins.py
+++ b/djangocms_form_builder/cms_plugins/form_plugins.py
@@ -260,3 +260,13 @@ class SubmitPlugin(mixin_factory("SubmitButton"), FormElementPlugin):
     form = forms.SubmitButtonForm
 
     render_template = f"djangocms_form_builder/{settings.framework}/widgets/submit.html"
+
+
+@plugin_pool.register_plugin
+class CaptchaPlugin(FormElementPlugin):
+    name = _("Captcha")
+    module = _("Forms")
+    model = models.Captcha
+    form = forms.CaptchaForm
+    fieldsets = ()
+    render_template = "djangocms_form_builder/widgets/captcha.html"

--- a/djangocms_form_builder/forms.py
+++ b/djangocms_form_builder/forms.py
@@ -613,3 +613,9 @@ class SubmitButtonForm(
         choices=constants.SUBMIT_BUTTON_CHOICES,
         initial=constants.SUBMIT_BUTTON_CHOICES[0][0],
     )
+
+
+class CaptchaForm(forms.ModelForm):
+    class Meta:
+        model = models.Captcha
+        fields = ()

--- a/djangocms_form_builder/migrations/0005_captcha.py
+++ b/djangocms_form_builder/migrations/0005_captcha.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("djangocms_form_builder", "0004_alter_form_captcha_requirement_and_more"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Captcha",
+            fields=[],
+            options={
+                "verbose_name": "Captcha",
+                "proxy": True,
+                "indexes": [],
+                "constraints": [],
+            },
+            bases=("djangocms_form_builder.formfield",),
+        ),
+    ]

--- a/djangocms_form_builder/migrations/0006_captcha.py
+++ b/djangocms_form_builder/migrations/0006_captcha.py
@@ -3,7 +3,7 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("djangocms_form_builder", "0004_alter_form_captcha_requirement_and_more"),
+        ("djangocms_form_builder", "0005_static_captcha_schema"),
     ]
 
     operations = [

--- a/djangocms_form_builder/models.py
+++ b/djangocms_form_builder/models.py
@@ -478,3 +478,9 @@ class SubmitButton(FormField):
     class Meta:
         proxy = True
         verbose_name = _("Submit button")
+
+
+class Captcha(FormField):
+    class Meta:
+        proxy = True
+        verbose_name = _("Captcha")

--- a/djangocms_form_builder/templates/djangocms_form_builder/ajax_form.html
+++ b/djangocms_form_builder/templates/djangocms_form_builder/ajax_form.html
@@ -10,11 +10,7 @@
             {% render_form form %}
         {% endfor %}
         {% if instance.child_plugin_instances and not has_captcha_plugin %}
-            {% if form.fields.captcha_field and instance.captcha_widget == "altcha" %}
-                {{ form.captcha_field }}
-            {% else %}
-                {% render_recaptcha_widget form  %}
-            {% endif %}
+            {% render_captcha_widget form %}
         {% endif %}
     </div>
 {% endspaceless %}

--- a/djangocms_form_builder/templates/djangocms_form_builder/ajax_form.html
+++ b/djangocms_form_builder/templates/djangocms_form_builder/ajax_form.html
@@ -9,7 +9,7 @@
         {% empty %}
             {% render_form form %}
         {% endfor %}
-        {% if instance.child_plugin_instances %}
+        {% if instance.child_plugin_instances and not has_captcha_plugin %}
             {% if form.fields.captcha_field and instance.captcha_widget == "altcha" %}
                 {{ form.captcha_field }}
             {% else %}

--- a/djangocms_form_builder/templates/djangocms_form_builder/widgets/captcha.html
+++ b/djangocms_form_builder/templates/djangocms_form_builder/widgets/captcha.html
@@ -1,1 +1,2 @@
-{% load form_builder_tags %}{% render_captcha_widget form %}
+{% load form_builder_tags %}
+{% render_captcha_widget form %}

--- a/djangocms_form_builder/templates/djangocms_form_builder/widgets/captcha.html
+++ b/djangocms_form_builder/templates/djangocms_form_builder/widgets/captcha.html
@@ -1,1 +1,1 @@
-{% load form_builder_tags %}{% if form.fields.captcha_field %}{% if captcha_widget == "altcha" %}{{ form.captcha_field }}{% else %}{% render_recaptcha_widget form %}{% endif %}{% endif %}
+{% load form_builder_tags %}{% render_captcha_widget form %}

--- a/djangocms_form_builder/templates/djangocms_form_builder/widgets/captcha.html
+++ b/djangocms_form_builder/templates/djangocms_form_builder/widgets/captcha.html
@@ -1,0 +1,1 @@
+{% load form_builder_tags %}{% if form.fields.captcha_field %}{% if captcha_widget == "altcha" %}{{ form.captcha_field }}{% else %}{% render_recaptcha_widget form %}{% endif %}{% endif %}

--- a/djangocms_form_builder/templatetags/form_builder_tags.py
+++ b/djangocms_form_builder/templatetags/form_builder_tags.py
@@ -151,10 +151,19 @@ def render_widget(form, form_field, **kwargs):
 
 
 @register.simple_tag(takes_context=False)
-def render_recaptcha_widget(form):
-    if recaptcha.installed:
-        return render_widget(form, recaptcha.field_name)
-    return ""
+def render_captcha_widget(form):
+    if form is None or recaptcha.field_name not in form.fields:
+        return ""
+    field = form[recaptcha.field_name]
+    if field.field.widget.__class__.__module__.startswith("django_altcha"):
+        return field.as_widget()
+    return render_widget(form, recaptcha.field_name)
+
+
+# Kept for compatibility with custom templates using the old tag name.
+render_recaptcha_widget = register.simple_tag(
+    takes_context=False, name="render_recaptcha_widget"
+)(render_captcha_widget)
 
 
 @register.filter_function

--- a/tests/test_form_rendering.py
+++ b/tests/test_form_rendering.py
@@ -464,6 +464,25 @@ class TemplateTagsTestCase(CMSTestCase):
 
         self.assertEqual(rendered.strip(), "")
 
+    def test_render_captcha_widget_with_recaptcha_widget(self):
+        template = Template(
+            "{% load form_builder_tags %}{% render_captcha_widget form %}"
+        )
+
+        class ReCaptchaWidget(forms.TextInput):
+            pass
+
+        class TestForm(forms.Form):
+            captcha_field = forms.CharField(
+                label="", widget=ReCaptchaWidget(attrs={"no_field_sep": True})
+            )
+
+        rendered = template.render(Context({"form": TestForm()}))
+
+        self.assertIn('name="captcha_field"', rendered)
+        self.assertIn('class="form-control"', rendered)
+        self.assertNotIn("no_field_sep", rendered)
+
 
 class AltchaIntegrationTestCase(TestFixture, CMSTestCase):
     """Tests for Altcha CAPTCHA integration (run only when django_altcha is installed)."""

--- a/tests/test_form_rendering.py
+++ b/tests/test_form_rendering.py
@@ -450,10 +450,9 @@ class TemplateTagsTestCase(CMSTestCase):
 
         self.assertIn("Personal Info", rendered)
 
-    def test_render_recaptcha_widget_when_not_installed(self):
-        """Test {% render_recaptcha_widget %} when recaptcha not available"""
+    def test_render_captcha_widget_without_captcha_field(self):
         template = Template(
-            "{% load form_builder_tags %}{% render_recaptcha_widget form %}"
+            "{% load form_builder_tags %}{% render_captcha_widget form %}"
         )
 
         class TestForm(forms.Form):
@@ -463,7 +462,6 @@ class TemplateTagsTestCase(CMSTestCase):
         context = Context({"form": form})
         rendered = template.render(context)
 
-        # Should return empty string when recaptcha not installed
         self.assertEqual(rendered.strip(), "")
 
 

--- a/tests/test_form_rendering.py
+++ b/tests/test_form_rendering.py
@@ -273,6 +273,52 @@ class FormRenderingTestCase(TestFixture, CMSTestCase):
         self.assertIn('challengeurl="/altcha/challenge/"', content)
         self.assertIn("altcha.min.js", content)
 
+    def test_captcha_plugin_controls_render_order(self):
+        form_plugin = add_plugin(
+            placeholder=self.placeholder,
+            plugin_type=cms_plugins.FormPlugin.__name__,
+            language=self.language,
+            form_selection="",
+            form_name="placed-captcha-form",
+            captcha_widget="altcha",
+        )
+        char_field = add_plugin(
+            placeholder=self.placeholder,
+            plugin_type=cms_plugins.CharFieldPlugin.__name__,
+            target=form_plugin,
+            language=self.language,
+            config={"field_name": "full_name", "field_label": "Full Name"},
+        )
+        char_field.initialize_from_form()
+        add_plugin(
+            placeholder=self.placeholder,
+            plugin_type=cms_plugins.CaptchaPlugin.__name__,
+            target=form_plugin,
+            language=self.language,
+        )
+        submit = add_plugin(
+            placeholder=self.placeholder,
+            plugin_type=cms_plugins.SubmitPlugin.__name__,
+            target=form_plugin,
+            language=self.language,
+            config={"submit_cta": "Send form"},
+        )
+        submit.initialize_from_form()
+
+        self.publish(self.page, self.language)
+
+        with self.login_user_context(self.superuser):
+            response = self.client.get(self.request_url)
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        field_position = content.index('name="full_name"')
+        captcha_position = content.index('name="captcha_field"')
+        submit_position = content.index('value="Send form"')
+        self.assertLess(field_position, captcha_position)
+        self.assertLess(captcha_position, submit_position)
+        self.assertEqual(content.count('challengeurl="/altcha/challenge/"'), 1)
+
 
 class TemplateTagsTestCase(CMSTestCase):
     """Tests for template tags in djangocms_form_builder"""

--- a/tests/test_formeditor.py
+++ b/tests/test_formeditor.py
@@ -25,7 +25,7 @@ class FormEditorTestCase(TestFixture, CMSTestCase):
                 inspect.isclass(cls)
                 and issubclass(cls, FormElementPlugin)
                 and not issubclass(cls, cms_plugins.ChoicePlugin)
-                and cls is not cms_plugins.SubmitPlugin
+                and cls not in (cms_plugins.SubmitPlugin, cms_plugins.CaptchaPlugin)
             ):
                 field = add_plugin(
                     placeholder=self.placeholder,
@@ -52,7 +52,7 @@ class FormEditorTestCase(TestFixture, CMSTestCase):
                 inspect.isclass(cls)
                 and issubclass(cls, FormElementPlugin)
                 and not issubclass(cls, cms_plugins.ChoicePlugin)
-                and cls is not cms_plugins.SubmitPlugin
+                and cls not in (cms_plugins.SubmitPlugin, cms_plugins.CaptchaPlugin)
             ):
                 self.assertContains(response, f'name="field_{item}"')
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce a dedicated Captcha form element plugin and integrate it into form rendering and AJAX form handling.

New Features:
- Add a CaptchaPlugin form element with corresponding Captcha model proxy and model form.
- Provide a captcha widget template that supports both Altcha and reCAPTCHA rendering based on configuration.

Enhancements:
- Update AJAX form context and template logic so captcha presence and widget type are controlled by the Captcha plugin and avoid duplicate captcha output.
- Adjust form editor tests and plugin imports to recognize the new CaptchaPlugin alongside existing form element plugins.

Tests:
- Add a form rendering test to verify that the Captcha plugin controls field, captcha, and submit button ordering and that the Altcha challenge is rendered exactly once.

## Related issues

* fixes #58