### PR TITLE
chore: Prepare release 0.6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,13 +2,17 @@
 Changelog
 =========
 
-Unreleased
-==========
+0.6.0 (2026-07-23)
+==================
 
+* feat: add FileUpload and MultipleFileUpload fields in forms by
+  @corentinbettiol in https://github.com/django-cms/djangocms-form-builder/pull/44
+* feat: Add Captcha form element plugin by @fsbraun in https://github.com/django-cms/djangocms-form-builder/pull/59
 * feat: Add ``prune_form_entries`` management command to enforce a retention
   policy for stored form entries
 * feat: The send email action logs failed deliveries to the
   ``djangocms_form_builder.actions`` logger instead of silently dropping them
+* feat: Security hardening for public forms by @fsbraun in https://github.com/django-cms/djangocms-form-builder/pull/57
 * fix: Make ``djangocms-text`` a soft dependency - the success message action
   falls back to a plain textarea if it is not installed
 * fix: ``SaveToDBAction`` no longer stores the ``User-Agent`` and ``Referer``
@@ -25,8 +29,15 @@ Unreleased
   rendering widgets
 * fix: Reserved form field name list contained ``html_header`` instead of
   ``html_headers``
+* fix: Enforce min/max length on CharField and TextareaField (#53) by @fsbraun
+  in https://github.com/django-cms/djangocms-form-builder/pull/56
 * chore: Remove dead code inherited from djangocms-frontend (device choice
   fields, icon widgets, template helpers, form mixin stubs, and more)
+
+**New Contributors**
+
+* @corentinbettiol made their first contribution in https://github.com/django-cms/djangocms-form-builder/pull/44
+
 
 0.5.1 (2026-06-01)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -74,13 +74,17 @@ Form fields
 
 Currently the following form fields are supported:
 
-* CharField, EmailField, URLField
-* DecimalField, IntegerField
-* Textarea
-* DateField, DateTimeField, TimeField
-* SelectField
-* BooleanField
-* FileField
+* Text, Textarea, Email and URL
+* Decimal and Integer
+* Date, Date and Time, and Time
+* Select/Choice and Boolean
+* File upload and Multiple file upload
+* Captcha
+
+Captcha providers are optional dependencies. Configure the provider and widget
+on the Form plugin; add a Captcha child plugin where the widget should appear in
+the structure-built form. Widget ``data-*`` attributes and CAPTCHA API
+parameters can be supplied in the Form plugin's CAPTCHA configuration.
 
 A Form plugin must not be used within another Form plugin.
 
@@ -286,7 +290,12 @@ File Upload and Multiple File Upload fields use
 ``django.core.files.storage.default_storage`` by default, but you can specify an
 alternative storage using ``DJANGOCMS_FORM_BUILDER_FILE_FIELD_STORAGE``.
 
-See **File Upload** in the doc for more info.
+Stored uploads belong to their saved form entry. Replacing an upload in a
+reopened unique form removes the old file; deleting or pruning the form entry
+removes its files through the configured storage backend.
+
+See **File Upload** in the documentation for validation presets, storage
+configuration, and lifecycle details.
 
 .. |pypi| image:: https://badge.fury.io/py/djangocms-form-builder.svg
    :target: http://badge.fury.io/py/djangocms-form-builder

--- a/djangocms_form_builder/__init__.py
+++ b/djangocms_form_builder/__init__.py
@@ -6,7 +6,7 @@ except ModuleNotFoundError:
     _ = lambda x: x  # noqa: E731
 
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"
 
 _form_registry = {}
 

--- a/docs/source/file_upload.rst
+++ b/docs/source/file_upload.rst
@@ -174,6 +174,26 @@ written to ``default_storage`` under ``form_uploads/...``, and each file field b
 a dict with ``_form_builder_file``, ``filename``, ``name`` (storage-relative path),
 and ``url``.
 
+Upload lifecycle
+================
+
+Stored uploads are managed together with the :class:`FormEntry` that references
+them:
+
+* reopening a unique form without choosing a new optional upload retains the
+  existing file;
+* replacing an upload removes the previous file after the updated entry has
+  been saved;
+* deleting a form entry, including deletion by ``prune_form_entries``, removes
+  its stored files through
+  ``DJANGOCMS_FORM_BUILDER_FILE_FIELD_STORAGE``;
+* if saving the entry or one file in a multiple upload fails, files already
+  written for that attempted submission are removed.
+
+Storage deletion failures are logged. Operators should monitor the
+``djangocms_form_builder.form_entry_data`` logger because a backend failure can
+leave an unreferenced file that needs manual cleanup.
+
 Plugin admin
 ============
 

--- a/docs/source/forms.rst
+++ b/docs/source/forms.rst
@@ -74,12 +74,56 @@ represent form fields. These are:
 * Select/Choice
 * URL
 * Email
+* File upload
+* Multiple file upload
+* Captcha
 
 Each field requires an input of then specific form. Some fields (e.g., Boolean
 or Select/Choice) offer options on the specific input widget.
 
 djangocms-form-builder will use framework specific widgets or fall back to standard
 widgets browsers offer (e.g., date picker).
+
+Text length limits
+------------------
+
+Text and Textarea plugins accept optional **Minimum text length** and **Maximum
+text length** settings. These limits are enforced during server-side form
+validation, not merely through browser attributes.
+
+File uploads
+------------
+
+The File upload and Multiple file upload plugins accept files in AJAX
+submissions. Multiple file uploads have an editor-configurable maximum file
+count. Storage, validation presets, public-access considerations, and file
+lifecycle are described in :doc:`file_upload`.
+
+Captcha placement and configuration
+-----------------------------------
+
+CAPTCHA support requires a supported optional provider such as
+``django-altcha`` or ``django-recaptcha``. Select and configure the CAPTCHA
+widget on the Form plugin. For a structure-built form, add a Captcha child
+plugin at the position where the widget should be rendered. If no Captcha child
+plugin is present, the widget is rendered in the form's default CAPTCHA
+position.
+
+The Form plugin's CAPTCHA configuration separates entries by name:
+
+* names beginning with ``data-`` are passed to the CAPTCHA widget as HTML
+  attributes;
+* all other names are passed as CAPTCHA API parameters.
+
+For Altcha installation and settings, see the corresponding section in the
+project README.
+
+Success message editor
+----------------------
+
+The Success message action uses ``djangocms-text`` for rich-text editing when
+that optional package is installed. Without it, the action remains usable and
+falls back to a plain textarea.
 
 ***************************
 Using forms from other apps
@@ -124,4 +168,3 @@ There are three ways **djangocms-form-builder** can render registered forms:
    rendered using **django-crispy-forms**. Note, however, that the submit button
    is rendered by the plugin. Hence do not include it into the form (which is
    possible with **django-crispy-forms**).
-

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -106,6 +106,62 @@ class ActionTestCase(TestFixture, CMSTestCase):
         self.assertEqual(entry.entry_data["attachment"]["name"], "form_uploads/new.pdf")
         storage.delete.assert_called_once_with("form_uploads/old.pdf")
 
+    @patch("djangocms_form_builder.actions.delete_stored_files")
+    @patch("djangocms_form_builder.actions.serialize_cleaned_data_for_entry")
+    def test_create_failure_cleans_up_new_uploads(self, serialize, delete_files):
+        serialized = {"attachment": {"name": "form_uploads/new.pdf"}}
+        serialize.return_value = serialized
+        form = self._unique_upload_form({"attachment": object()})
+        form.Meta.options["unique"] = False
+
+        with patch.object(FormEntry.objects, "create", side_effect=OSError("db down")):
+            with self.assertRaisesMessage(OSError, "db down"):
+                SaveToDBAction().execute(
+                    form,
+                    self._authenticated_upload_request(),
+                )
+
+        delete_files.assert_called_once_with(serialized)
+
+    @patch("djangocms_form_builder.actions.delete_stored_files")
+    @patch("djangocms_form_builder.actions.serialize_cleaned_data_for_entry")
+    def test_update_failure_preserves_previous_upload_during_cleanup(
+        self, serialize, delete_files
+    ):
+        old_metadata = {
+            "_form_builder_file": True,
+            "filename": "old.pdf",
+            "name": "form_uploads/old.pdf",
+            "url": "/media/form_uploads/old.pdf",
+        }
+        FormEntry.objects.create(
+            form_name="unique-upload",
+            form_user=self.superuser,
+            entry_data={"attachment": old_metadata},
+        )
+        serialized = {
+            "attachment": {
+                "_form_builder_file": True,
+                "filename": "new.pdf",
+                "name": "form_uploads/new.pdf",
+                "url": "/media/form_uploads/new.pdf",
+            }
+        }
+        serialize.return_value = serialized
+
+        with patch.object(
+            FormEntry.objects, "update_or_create", side_effect=OSError("db down")
+        ):
+            with self.assertRaisesMessage(OSError, "db down"):
+                SaveToDBAction().execute(
+                    self._unique_upload_form({"attachment": object()}),
+                    self._authenticated_upload_request(),
+                )
+
+        delete_files.assert_called_once_with(
+            serialized, excluding={"form_uploads/old.pdf"}
+        )
+
     def test_send_mail_action(self):
         plugin_instance = add_plugin(
             placeholder=self.placeholder,

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from cms.api import add_plugin
 from cms.test_utils.testcases import CMSTestCase
@@ -161,6 +161,50 @@ class ActionTestCase(TestFixture, CMSTestCase):
         delete_files.assert_called_once_with(
             serialized, excluding={"form_uploads/old.pdf"}
         )
+
+    @patch("djangocms_form_builder.actions.delete_stored_files")
+    @patch("djangocms_form_builder.actions.serialize_cleaned_data_for_entry")
+    def test_duplicate_recovery_failure_cleans_up_new_uploads(
+        self, serialize, delete_files
+    ):
+        FormEntry.objects.create(
+            form_name="unique-upload",
+            form_user=self.superuser,
+            entry_data={"value": "first"},
+        )
+        FormEntry.objects.create(
+            form_name="unique-upload",
+            form_user=self.superuser,
+            entry_data={"value": "second"},
+        )
+        existing_entries = FormEntry.objects.filter(
+            form_name="unique-upload", form_user=self.superuser
+        )
+        cleanup_queryset = Mock()
+        serialized = {"attachment": {"name": "form_uploads/new.pdf"}}
+        serialize.return_value = serialized
+
+        with (
+            patch.object(
+                FormEntry.objects,
+                "update_or_create",
+                side_effect=FormEntry.MultipleObjectsReturned,
+            ),
+            patch.object(FormEntry.objects, "create", side_effect=OSError("db down")),
+            patch.object(
+                FormEntry.objects,
+                "filter",
+                side_effect=[existing_entries, cleanup_queryset],
+            ),
+        ):
+            with self.assertRaisesMessage(OSError, "db down"):
+                SaveToDBAction().execute(
+                    self._unique_upload_form({"attachment": object()}),
+                    self._authenticated_upload_request(),
+                )
+
+        cleanup_queryset.delete.assert_called_once()
+        delete_files.assert_called_once_with(serialized)
 
     def test_send_mail_action(self):
         plugin_instance = add_plugin(

--- a/tests/test_ajax_plugin.py
+++ b/tests/test_ajax_plugin.py
@@ -6,8 +6,8 @@ from cms import __version__ as cms_version
 from cms.api import add_plugin
 from cms.test_utils.testcases import CMSTestCase
 from django import forms
-from django.core.exceptions import ImproperlyConfigured
-from django.http import HttpResponseNotAllowed, JsonResponse
+from django.core.exceptions import ImproperlyConfigured, ValidationError
+from django.http import Http404, HttpResponse, HttpResponseNotAllowed, JsonResponse
 from django.test import RequestFactory, override_settings
 from django.urls import reverse
 
@@ -470,6 +470,71 @@ class RegisterFormViewTestCase(CMSTestCase):
 
         with self.assertRaises(ImproperlyConfigured):
             register_form_view(FormView2, slug="conflicting-slug")
+
+    def test_registered_view_delegates_ajax_post_and_get(self):
+        class FormView:
+            def ajax_post(self, request, *args, **kwargs):
+                return HttpResponse("ajax-post")
+
+            def ajax_get(self, request, *args, **kwargs):
+                return HttpResponse("ajax-get")
+
+        key = register_form_view(FormView, slug="ajax-delegation")
+        request = RequestFactory().get("/")
+
+        self.assertEqual(
+            AjaxView().ajax_post(request, form_id=key).content, b"ajax-post"
+        )
+        self.assertEqual(AjaxView().ajax_get(request, form_id=key).content, b"ajax-get")
+
+    def test_registered_view_uses_standard_method_fallbacks(self):
+        class FormView:
+            def post(self, request, *args, **kwargs):
+                return HttpResponse("post")
+
+            def get(self, request, *args, **kwargs):
+                return HttpResponse("get")
+
+        key = register_form_view(FormView, slug="method-fallback")
+        request = RequestFactory().get("/")
+
+        self.assertEqual(AjaxView().ajax_post(request, form_id=key).content, b"post")
+        self.assertEqual(AjaxView().ajax_get(request, form_id=key).content, b"get")
+
+    def test_unknown_or_handlerless_registered_view_returns_404(self):
+        key = register_form_view(object, slug="handlerless")
+        request = RequestFactory().get("/")
+
+        for method in (AjaxView().ajax_post, AjaxView().ajax_get):
+            with self.subTest(method=method.__name__, case="unknown"):
+                with self.assertRaises(Http404):
+                    method(request, form_id="unknown")
+            with self.subTest(method=method.__name__, case="handlerless"):
+                with self.assertRaises(Http404):
+                    method(request, form_id=key)
+
+    def test_plugin_validation_errors_are_json_responses(self):
+        class Plugin:
+            def ajax_post(self, request, instance, params):
+                raise ValidationError("bad post")
+
+            def ajax_get(self, request, instance, params):
+                raise ValidationError("bad get")
+
+        request = RequestFactory().get("/")
+        request.user = mock.Mock(is_staff=False)
+        view = AjaxView()
+
+        with mock.patch.object(
+            view, "plugin_instance", return_value=(Plugin(), object())
+        ):
+            post = view.ajax_post(request, instance_id=1)
+            get = view.ajax_get(request, instance_id=1)
+
+        self.assertEqual(
+            json.loads(post.content), {"result": "error", "msg": "bad post"}
+        )
+        self.assertEqual(json.loads(get.content), {"result": "error", "msg": "bad get"})
 
 
 class AjaxGetRequestTestCase(TestFixture, CMSTestCase):

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -311,6 +311,42 @@ class BuiltinValidatorFunctionTests(SimpleTestCase):
         with self.assertRaises(FileValidationError):
             enforce_mime_from_filename(bad, ["application/pdf"], field_name="a")
 
+    def test_max_size_boundary_and_human_readable_limits(self):
+        exact = SimpleUploadedFile("exact.bin", b"1234")
+        enforce_max_size(exact, 4)
+
+        cases = (
+            (512, "512 bytes"),
+            (1536, "1.5 KB"),
+            (2 * 1024 * 1024, "2 MB"),
+        )
+        for limit, expected in cases:
+            with self.subTest(limit=limit):
+                too_large = SimpleUploadedFile("large.bin", b"x")
+                too_large.size = limit + 1
+                with self.assertRaisesMessage(FileValidationError, expected):
+                    enforce_max_size(too_large, limit)
+
+    def test_extension_normalization_and_empty_allowlist(self):
+        enforce_extension(SimpleUploadedFile("REPORT.PDF", b"x"), [" pdf "])
+
+        with self.assertRaisesMessage(
+            FileValidationError, 'File "report.pdf" has a disallowed extension.'
+        ):
+            enforce_extension(SimpleUploadedFile("report.pdf", b"x"), [])
+
+    def test_mime_empty_patterns_skip_check_and_unknown_type_is_rejected(self):
+        unknown = SimpleUploadedFile("payload.unknown-form-builder-type", b"x")
+        enforce_mime_from_filename(unknown, [])
+
+        with self.assertRaisesMessage(
+            FileValidationError, 'Could not determine file type for "payload'
+        ):
+            enforce_mime_from_filename(unknown, ["application/pdf"])
+
+    def test_mime_prefix_matches_category(self):
+        enforce_mime_from_filename(SimpleUploadedFile("image.png", b"x"), ["image/"])
+
 
 class AcceptAttributeTests(SimpleTestCase):
     @override_settings(

--- a/tests/test_form_entry_data.py
+++ b/tests/test_form_entry_data.py
@@ -58,6 +58,40 @@ class SerializeCleanedDataTests(TestCase):
         mock_storage.delete.assert_called_once_with("form_uploads/a.txt")
 
 
+class FormEntryMailDataTests(TestCase):
+    def test_mail_data_separates_file_links_from_regular_values(self):
+        entry = FormEntry(
+            entry_data={
+                "name": "Ada",
+                "attachments": [
+                    {
+                        "_form_builder_file": True,
+                        "filename": "public.pdf",
+                        "name": "form_uploads/internal-token.pdf",
+                        "url": "/media/form_uploads/public.pdf",
+                        "content_type": "application/pdf",
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(
+            entry.get_mail_data(),
+            [
+                {"label": "name", "value": "Ada"},
+                {
+                    "label": "attachments",
+                    "files": [
+                        {
+                            "filename": "public.pdf",
+                            "url": "/media/form_uploads/public.pdf",
+                        }
+                    ],
+                },
+            ],
+        )
+
+
 class DeleteEntryFilesTests(TestCase):
     @patch("djangocms_form_builder.form_entry_data.FILE_FIELD_STORAGE")
     def test_delete_entry_calls_storage_delete_for_single_file(self, mock_storage):

--- a/tests/test_forms_validation.py
+++ b/tests/test_forms_validation.py
@@ -1,0 +1,53 @@
+from django.core.exceptions import ValidationError
+from django.test import SimpleTestCase
+
+from djangocms_form_builder import actions
+from djangocms_form_builder.forms import FormsForm
+
+
+class FormsFormValidationTests(SimpleTestCase):
+    def _clean(self, **overrides):
+        cleaned_data = {
+            "form_selection": "",
+            "form_name": "feedback",
+            "form_actions": [actions.SAVE_TO_DB_ACTION],
+            "form_unique": False,
+            "form_login_required": False,
+        }
+        cleaned_data.update(overrides)
+        form = FormsForm()
+        form.cleaned_data = cleaned_data
+        return form.clean()
+
+    def test_custom_form_requires_name(self):
+        with self.assertRaises(ValidationError) as ctx:
+            self._clean(form_name="")
+        self.assertIn("form_name", ctx.exception.error_dict)
+
+    def test_unique_form_requires_database_action(self):
+        with self.assertRaises(ValidationError) as ctx:
+            self._clean(form_unique=True, form_actions=[])
+        self.assertEqual(set(ctx.exception.error_dict), {"form_actions", "form_unique"})
+
+    def test_missing_actions_are_rejected(self):
+        form = FormsForm()
+        form.cleaned_data = {
+            "form_selection": "",
+            "form_name": "feedback",
+            "form_unique": False,
+            "form_login_required": False,
+        }
+        with self.assertRaises(ValidationError) as ctx:
+            form.clean()
+        self.assertIn("form_actions", ctx.exception.error_dict)
+
+    def test_unique_form_requires_login(self):
+        with self.assertRaises(ValidationError) as ctx:
+            self._clean(form_unique=True)
+        self.assertEqual(
+            set(ctx.exception.error_dict), {"form_login_required", "form_unique"}
+        )
+
+    def test_consistent_unique_form_is_accepted(self):
+        cleaned_data = self._clean(form_unique=True, form_login_required=True)
+        self.assertTrue(cleaned_data["form_unique"])


### PR DESCRIPTION
## Summary by Sourcery

Prepare the 0.6.0 release by updating the package version and associated release metadata.

Build:
- Bump the package version from 0.5.1 to 0.6.0 in the distribution metadata.

Chores:
- Update changelog for the 0.6.0 release.