### PR TITLE
fix: Do not cache parent classes of form element plugins

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ unpublished
   ``DJANGOCMS_CONFIRMATION_MAIL_TEMPLATE_SETS`` - no templates are shipped
 * feat: Form actions can be rate limited per client and per action-specific
   value (e.g. a mail recipient) through ``DJANGOCMS_FORM_BUILDER_RATE_LIMITS``
+* fix: Form element plugins no longer cache their parent classes. Their
+  ``get_parent_classes()`` walks the ancestor tree to find the surrounding
+  form, so the result depends on where the plugin sits in the hierarchy and
+  must be recomputed per instance
 
 
 0.6.0 (2026-07-23)

--- a/djangocms_form_builder/cms_plugins/form_plugins.py
+++ b/djangocms_form_builder/cms_plugins/form_plugins.py
@@ -20,6 +20,9 @@ class FormElementPlugin(CMSPluginBase):
     # Form elements are rendered by the surrounding FormPlugin, hence any change has to be
     # propageted up to the FormPlugin:
     is_local = False
+    # get_parent_classes walks the instance's ancestor tree to find a FormPlugin,
+    # so the result varies by position in the plugin hierarchy and must not be cached.
+    cache_parent_classes = False
 
     fieldsets = (
         (

--- a/tests/test_ajax_plugin.py
+++ b/tests/test_ajax_plugin.py
@@ -651,6 +651,50 @@ class FormPluginTestCase(TestFixture, CMSTestCase):
         # Should return [""] which means no valid parent (prevents nesting)
         self.assertEqual(result, [""])
 
+    def test_form_element_parent_classes_are_not_cached(self):
+        """FormElementPlugin.get_parent_classes depends on the instance's ancestors.
+
+        django CMS caches get_parent_classes per plugin type, so form element
+        plugins must opt out of that cache or the first answer would be reused
+        for every instance regardless of its position in the tree.
+        """
+        self.assertFalse(cms_plugins.CharFieldPlugin.cache_parent_classes)
+
+    def test_form_element_get_parent_classes_depends_on_position(self):
+        """A field inside a form is allowed; the same field type outside one is not"""
+        form = add_plugin(
+            placeholder=self.placeholder,
+            plugin_type=cms_plugins.FormPlugin.__name__,
+            language=self.language,
+            form_name="a-form",
+        )
+        inside = add_plugin(
+            placeholder=self.placeholder,
+            plugin_type=cms_plugins.CharFieldPlugin.__name__,
+            target=form,
+            language=self.language,
+            config={"field_name": "inside", "field_label": "Inside"},
+        )
+        outside = add_plugin(
+            placeholder=self.placeholder,
+            plugin_type=cms_plugins.CharFieldPlugin.__name__,
+            language=self.language,
+            config={"field_name": "outside", "field_label": "Outside"},
+        )
+
+        self.assertNotEqual(
+            cms_plugins.CharFieldPlugin.get_parent_classes(
+                slot=None, page=None, instance=inside
+            ),
+            [""],
+        )
+        self.assertEqual(
+            cms_plugins.CharFieldPlugin.get_parent_classes(
+                slot=None, page=None, instance=outside
+            ),
+            [""],
+        )
+
     def test_form_plugin_allows_form_as_top_level(self):
         """Test that FormPlugin is allowed at top level"""
         # Without an instance (top level), should allow normal parent classes


### PR DESCRIPTION
## Description

`FormElementPlugin.get_parent_classes()` walks the instance's ancestor tree to verify that the element sits below a `FormPlugin`, returning `[""]` (no valid parent) otherwise:

https://github.com/django-cms/djangocms-form-builder/blob/main/djangocms_form_builder/cms_plugins/form_plugins.py#L37-L47

Its answer therefore depends on **where the instance sits in the plugin hierarchy**, not just on the plugin type.

django CMS memoises `get_parent_classes()` in the restrictions cache keyed by plugin *type* only (`cms/utils/plugins.py`):

```python
try:
    parent_classes = parents_cache[plugin_type]
except KeyError:
    parent_classes = plugin_class.get_parent_classes(...)

if plugin_class.cache_parent_classes:
    parents_cache[plugin_type] = parent_classes or []
```

So the verdict computed for the first instance of, say, `CharFieldPlugin` is reused for every other `CharFieldPlugin` in the same tree. A field inside a form and a field of the same type outside one end up sharing a single cached answer, and the structure toolbar offers (or refuses) parents based on whichever instance happened to be evaluated first.

`CMSPluginBase` provides `cache_parent_classes` exactly for this case, and `FormPlugin` already opts out of the cache for the very same ancestor-walking reason:

https://github.com/django-cms/djangocms-form-builder/blob/main/djangocms_form_builder/cms_plugins/ajax_plugins.py#L294

`FormElementPlugin` performs the same kind of walk but was missed. This PR sets `cache_parent_classes = False` on it, so all form element plugins inherit the opt-out.

## Notes

- The attribute is inert on django CMS < 5 (the project supports `django-cms>=3.10`), so this is safe across the supported matrix — it is simply an unused class attribute there.
- There is a performance cost by design: parent/child relations for form elements are recomputed per render, which is the same trade-off `FormPlugin` already makes and the only way to get correct results from a position-dependent override.

## Testing

Two tests added to `tests/test_ajax_plugin.py`:

- `test_form_element_parent_classes_are_not_cached` — guards the opt-out; verified to fail on `main` without the fix.
- `test_form_element_get_parent_classes_depends_on_position` — documents that the same field plugin type yields different parent classes inside vs. outside a form, which is what makes caching unsound.

Full suite passes locally (280 tests, Django 5.2 / django CMS 5.0), `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141UmA22Z486ZE1vTj7Gjv4

## Summary by Sourcery

Disable parent-class caching for form element plugins so parent restrictions accurately reflect each instance’s position in the plugin tree.

Bug Fixes:
- Prevent form element parent restrictions from being incorrectly reused across plugin instances in different hierarchy positions.

Tests:
- Add coverage confirming form element parent restrictions are position-dependent and not cached.